### PR TITLE
Fix RSSI offset for pre-msg RSSI notification

### DIFF
--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -219,6 +219,12 @@ uint8_t LoRaClass::packetRssiRaw() {
 
 int LoRaClass::packetRssi() {
   int pkt_rssi = (int)readRegister(REG_PKT_RSSI_VALUE);
+  int8_t pkt_snr = ((int8_t)readRegister(REG_PKT_SNR_VALUE));
+  if pkt_snr < 0 {
+    pkt_rssi = pkt_rssi * 16 / 15;
+  } else {
+    pkt_rssi += pkt_snr / 4;
+  }
   // TODO: change this to look at the actual model code
   if (_frequency < 820E6) pkt_rssi -= 7;
   pkt_rssi -= 157;

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -144,7 +144,7 @@ void receiveCallback(int packet_size) {
       // recieved packet to the host.
       Serial.write(FEND);
       Serial.write(CMD_STAT_RSSI);
-      Serial.write((uint8_t)(last_rssi-rssi_offset));
+      Serial.write((uint8_t)(last_rssi+rssi_offset));
       Serial.write(FEND);
 
       // And then write the entire packet
@@ -170,7 +170,7 @@ void receiveCallback(int packet_size) {
     // recieved packet to the host.
     Serial.write(FEND);
     Serial.write(CMD_STAT_RSSI);
-    Serial.write((uint8_t)(last_rssi-rssi_offset));
+    Serial.write((uint8_t)(last_rssi+rssi_offset));
     Serial.write(FEND);
 
     // And then write the entire packet


### PR DESCRIPTION
last_rssi is a large negative number, with rssi_offset being +292,
intended to be added to put the value inside the range of a single byte uint.
Before sending the data message, a RSSI message is automatically sent,
which is quite nice, but the value ends up overflowing the 8-bit uint, giving
a bogus value.