### PR TITLE
LoRa: Enable LowDataRateOptimize for symbol length >16ms

### DIFF
--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -418,6 +418,8 @@ void LoRaClass::setSpreadingFactor(int sf)
   }
 
   writeRegister(REG_MODEM_CONFIG_2, (readRegister(REG_MODEM_CONFIG_2) & 0x0f) | ((sf << 4) & 0xf0));
+
+  handleLowDataRate();
 }
 
 long LoRaClass::getSignalBandwidth()
@@ -434,6 +436,18 @@ long LoRaClass::getSignalBandwidth()
     case 7: return 125E3; 
     case 8: return 250E3; 
     case 9: return 500E3; 
+  }
+}
+
+void LoRaClass::handleLowDataRate(){
+  int sf = (readRegister(REG_MODEM_CONFIG_2) >> 4);
+  if ( long( (1<<sf) / (getSignalBandwidth()/1000)) > 16) {
+    // set auto AGC and LowDataRateOptimize
+    writeRegister(REG_MODEM_CONFIG_3, (1<<3)|(1<<2));
+  }
+  else {
+    // set auto AGC
+    writeRegister(REG_MODEM_CONFIG_3, (1<<2));
   }
 }
 
@@ -464,6 +478,8 @@ void LoRaClass::setSignalBandwidth(long sbw)
   }
 
   writeRegister(REG_MODEM_CONFIG_1, (readRegister(REG_MODEM_CONFIG_1) & 0x0f) | (bw << 4));
+  
+  handleLowDataRate();
 }
 
 void LoRaClass::setCodingRate4(int denominator)

--- a/LoRa.h
+++ b/LoRa.h
@@ -82,6 +82,8 @@ private:
 
   static void onDio0Rise();
 
+  void handleLowDataRate();
+
 private:
   SPISettings _spiSettings;
   int _ss;


### PR DESCRIPTION
Found that issue when trying to receive a 125kHz, SF 12 LoRa signal, which did not work.
For low data rates (symbol length > 16ms), the LowDataRateOptimize bit should be set according to the Semtech SX1276/77/78/79 Datasheet. Transmitter and receiver must have the same setting.
I noticed a huge improvement using this feature.