### PR TITLE
Allow building for Linux as a Linux binary

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -1,19 +1,12 @@
 #include "ROM.h"
 
+#include "Platform.h"
+
 #ifndef CONFIG_H
 	#define CONFIG_H
 
 	#define MAJ_VERS  0x01
 	#define MIN_VERS  0x1B
-
-	#define PLATFORM_AVR   0x90
-    #define PLATFORM_ESP32 0x80
-    #define PLATFORM_LINUX 0x70
-
-	#define MCU_1284P 0x91
-	#define MCU_2560  0x92
-	#define MCU_ESP32 0x81
-    #define MCU_LINUX 0x71
 
 	#define BOARD_RNODE         0x31
 	#define BOARD_HMBRW         0x32
@@ -24,24 +17,25 @@
 	#define BOARD_LORA32_V2_1   0x37
     #define BOARD_SPIDEV        0x38
     
-    #define LIBRARY_ARDUINO     0x1
-    #define LIBRARY_C           0x2
-
 	#define MODE_HOST 0x11
 	#define MODE_TNC  0x12
 
 	#if defined(__AVR_ATmega1284P__)
 	    #define PLATFORM PLATFORM_AVR
 	    #define MCU_VARIANT MCU_1284P
+        #define LIBRARY_TYPE LIBRARY_ARDUINO
 	#elif defined(__AVR_ATmega2560__)
 	    #define PLATFORM PLATFORM_AVR
 	    #define MCU_VARIANT MCU_2560
+        #define LIBRARY_TYPE LIBRARY_ARDUINO
 	#elif defined(ESP32)
 	    #define PLATFORM PLATFORM_ESP32
 	    #define MCU_VARIANT MCU_ESP32
+        #define LIBRARY_TYPE LIBRARY_ARDUINO
     #elif defined(__unix__)
         #define PLATFORM PLATFORM_LINUX
         #define MCU_VARIANT MCU_LINUX
+        #define LIBRARY_TYPE LIBRARY_C
 	#else
 	    #error "The firmware cannot be compiled for the selected MCU variant"
 	#endif
@@ -63,7 +57,6 @@
 		const int pin_led_tx = 13;
 
 		#define BOARD_MODEL BOARD_RNODE
-        #define LIBRARY_TYPE LIBRARY_ARDUINO
 
 		#define CONFIG_UART_BUFFER_SIZE 6144
 		#define CONFIG_QUEUE_SIZE 6144
@@ -80,7 +73,6 @@
 		const int pin_led_tx = 13;
 
 		#define BOARD_MODEL BOARD_HMBRW
-        #define LIBRARY_TYPE LIBRARY_ARDUINO
 
 		#define CONFIG_UART_BUFFER_SIZE 768
 		#define CONFIG_QUEUE_SIZE 5120
@@ -142,8 +134,6 @@
 			#error An unsupported board was selected. Cannot compile RNode firmware.
 		#endif
         
-        #define LIBRARY_TYPE LIBRARY_ARDUINO
-
 		#define CONFIG_UART_BUFFER_SIZE 6144
 		#define CONFIG_QUEUE_SIZE 6144
 		#define CONFIG_QUEUE_MAX_LENGTH 200
@@ -162,7 +152,6 @@
 		const int pin_led_tx = -1;
 
 		#define BOARD_MODEL BOARD_SPIDEV
-        #define LIBRARY_TYPE LIBRARY_C
 
 		#define CONFIG_UART_BUFFER_SIZE 6144
 		#define CONFIG_QUEUE_SIZE 6144

--- a/Config.h
+++ b/Config.h
@@ -8,10 +8,12 @@
 
 	#define PLATFORM_AVR   0x90
     #define PLATFORM_ESP32 0x80
+    #define PLATFORM_LINUX 0x70
 
 	#define MCU_1284P 0x91
 	#define MCU_2560  0x92
 	#define MCU_ESP32 0x81
+    #define MCU_LINUX 0x71
 
 	#define BOARD_RNODE         0x31
 	#define BOARD_HMBRW         0x32
@@ -20,6 +22,10 @@
 	#define BOARD_GENERIC_ESP32 0x35
 	#define BOARD_LORA32_V2_0   0x36
 	#define BOARD_LORA32_V2_1   0x37
+    #define BOARD_SPIDEV        0x38
+    
+    #define LIBRARY_ARDUINO     0x1
+    #define LIBRARY_C           0x2
 
 	#define MODE_HOST 0x11
 	#define MODE_TNC  0x12
@@ -33,6 +39,9 @@
 	#elif defined(ESP32)
 	    #define PLATFORM PLATFORM_ESP32
 	    #define MCU_VARIANT MCU_ESP32
+    #elif defined(__unix__)
+        #define PLATFORM PLATFORM_LINUX
+        #define MCU_VARIANT MCU_LINUX
 	#else
 	    #error "The firmware cannot be compiled for the selected MCU variant"
 	#endif
@@ -54,6 +63,7 @@
 		const int pin_led_tx = 13;
 
 		#define BOARD_MODEL BOARD_RNODE
+        #define LIBRARY_TYPE LIBRARY_ARDUINO
 
 		#define CONFIG_UART_BUFFER_SIZE 6144
 		#define CONFIG_QUEUE_SIZE 6144
@@ -70,6 +80,7 @@
 		const int pin_led_tx = 13;
 
 		#define BOARD_MODEL BOARD_HMBRW
+        #define LIBRARY_TYPE LIBRARY_ARDUINO
 
 		#define CONFIG_UART_BUFFER_SIZE 768
 		#define CONFIG_QUEUE_SIZE 5120
@@ -130,6 +141,8 @@
 		#else
 			#error An unsupported board was selected. Cannot compile RNode firmware.
 		#endif
+        
+        #define LIBRARY_TYPE LIBRARY_ARDUINO
 
 		#define CONFIG_UART_BUFFER_SIZE 6144
 		#define CONFIG_QUEUE_SIZE 6144
@@ -141,6 +154,22 @@
 		#define GPS_BAUD_RATE 9600
 		#define PIN_GPS_TX 12
 		#define PIN_GPS_RX 34
+    #elif MCU_VARIANT == MCU_LINUX
+        const int pin_cs = -1;
+		const int pin_reset = -1;
+		const int pin_dio = -1;
+		const int pin_led_rx = -1;
+		const int pin_led_tx = -1;
+
+		#define BOARD_MODEL BOARD_SPIDEV
+        #define LIBRARY_TYPE LIBRARY_C
+
+		#define CONFIG_UART_BUFFER_SIZE 6144
+		#define CONFIG_QUEUE_SIZE 6144
+		#define CONFIG_QUEUE_MAX_LENGTH 200
+
+		#define EEPROM_SIZE 4096
+		#define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
 	#endif
 
 	#if BOARD_MODEL == BOARD_TBEAM
@@ -148,7 +177,12 @@
 		#define I2C_SCL 22
 		#define PMU_IRQ 35
 	#endif
-
+    
+    #if LIBRARY_TYPE == LIBRARY_C
+        // We need standard int types before we go any further
+        #include <cstdint>
+    #endif
+    
 	#define eeprom_addr(a) (a+EEPROM_OFFSET)
 
 	// MCU independent configuration parameters

--- a/Config.h
+++ b/Config.h
@@ -15,7 +15,6 @@
 	#define BOARD_GENERIC_ESP32 0x35
 	#define BOARD_LORA32_V2_0   0x36
 	#define BOARD_LORA32_V2_1   0x37
-    #define BOARD_SPIDEV        0x38
     
     #define SERIAL_INTERRUPT    0x1
     #define SERIAL_POLLING      0x2
@@ -138,7 +137,7 @@
 		const int pin_led_rx = -1;
 		const int pin_led_tx = -1;
 
-		#define BOARD_MODEL BOARD_SPIDEV
+		#define BOARD_MODEL BOARD_HMBRW
         #define SERIAL_EVENTS SERIAL_POLLING
 
 		#define CONFIG_UART_BUFFER_SIZE 6144

--- a/Config.h
+++ b/Config.h
@@ -17,28 +17,11 @@
 	#define BOARD_LORA32_V2_1   0x37
     #define BOARD_SPIDEV        0x38
     
+    #define SERIAL_INTERRUPT    0x1
+    #define SERIAL_POLLING      0x2
+    
 	#define MODE_HOST 0x11
 	#define MODE_TNC  0x12
-
-	#if defined(__AVR_ATmega1284P__)
-	    #define PLATFORM PLATFORM_AVR
-	    #define MCU_VARIANT MCU_1284P
-        #define LIBRARY_TYPE LIBRARY_ARDUINO
-	#elif defined(__AVR_ATmega2560__)
-	    #define PLATFORM PLATFORM_AVR
-	    #define MCU_VARIANT MCU_2560
-        #define LIBRARY_TYPE LIBRARY_ARDUINO
-	#elif defined(ESP32)
-	    #define PLATFORM PLATFORM_ESP32
-	    #define MCU_VARIANT MCU_ESP32
-        #define LIBRARY_TYPE LIBRARY_ARDUINO
-    #elif defined(__unix__)
-        #define PLATFORM PLATFORM_LINUX
-        #define MCU_VARIANT MCU_LINUX
-        #define LIBRARY_TYPE LIBRARY_C
-	#else
-	    #error "The firmware cannot be compiled for the selected MCU variant"
-	#endif
 
 	#define MTU   	   500
 	#define SINGLE_MTU 255
@@ -57,6 +40,7 @@
 		const int pin_led_tx = 13;
 
 		#define BOARD_MODEL BOARD_RNODE
+        #define SERIAL_EVENTS SERIAL_INTERRUPT
 
 		#define CONFIG_UART_BUFFER_SIZE 6144
 		#define CONFIG_QUEUE_SIZE 6144
@@ -73,6 +57,7 @@
 		const int pin_led_tx = 13;
 
 		#define BOARD_MODEL BOARD_HMBRW
+        #define SERIAL_EVENTS SERIAL_INTERRUPT
 
 		#define CONFIG_UART_BUFFER_SIZE 768
 		#define CONFIG_QUEUE_SIZE 5120
@@ -134,6 +119,8 @@
 			#error An unsupported board was selected. Cannot compile RNode firmware.
 		#endif
         
+        #define SERIAL_EVENTS SERIAL_POLLING
+        
 		#define CONFIG_UART_BUFFER_SIZE 6144
 		#define CONFIG_QUEUE_SIZE 6144
 		#define CONFIG_QUEUE_MAX_LENGTH 200
@@ -152,6 +139,7 @@
 		const int pin_led_tx = -1;
 
 		#define BOARD_MODEL BOARD_SPIDEV
+        #define SERIAL_EVENTS SERIAL_POLLING
 
 		#define CONFIG_UART_BUFFER_SIZE 6144
 		#define CONFIG_QUEUE_SIZE 6144

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -219,7 +219,7 @@ int LoRaClass::endPacket()
   std::cerr << "Entering transmit mode" << std::endl;
   for (uint8_t i = REG_OP_MODE ; i <= REG_PA_DAC; i++) {
     uint8_t val = readRegister(i);
-    std::cerr << std::hex << "0x" << i << " 0x" << val << std::dec << std::endl;
+    std::cerr << std::hex << "0x" << (int)i << " 0x" << (int)val << std::dec << std::endl;
   }
 #endif
   // put in TX mode
@@ -712,9 +712,9 @@ bool LoRaClass::resetModem()
       REG_HOP_PERIOD, 0x00,
       REG_MODEM_CONFIG_3, 0x04,
       REG_PPM_CORRECTION, 0x00,
-      REG_DETECTION_OPTIMIZE, 0xc3, // Errata says this needs to be set before REG_IF_FREQ_1 and REG_IF_FREQ_2
-      REG_IF_FREQ_2, 0x45, // Datasheet says this defaults to 0x20, but dumping says 0x45.
-      REG_IF_FREQ_1, 0x55, // Datasheet says this defaults to 0x00, but dumping says 0x55.
+      //REG_DETECTION_OPTIMIZE, 0xc3, // Errata says this needs to be set before REG_IF_FREQ_1 and REG_IF_FREQ_2
+      //REG_IF_FREQ_2, 0x45, // Datasheet says this defaults to 0x20, but dumping says 0x45.
+      //REG_IF_FREQ_1, 0x55, // Datasheet says this defaults to 0x00, but dumping says 0x55.
       REG_INVERT_IQ, 0x27,
       REG_HIGH_BW_OPTIMIZE_1, 0x03,
       REG_DETECTION_THRESHOLD, 0x0a,

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -215,6 +215,13 @@ int LoRaClass::beginPacket(int implicitHeader)
 
 int LoRaClass::endPacket()
 {
+#elif LIBRARY_TYPE == LIBRARY_C
+  std::cerr << "Entering transmit mode" << std::endl;
+  for (uint8_t i = REG_OP_MODE ; i <= REG_PA_DAC; i++) {
+    uint8_t val = readRegister(i);
+    std::cerr << std::hex << "0x" << i << " 0x" << val << std::dec << std::endl;
+  }
+#endif
   // put in TX mode
   writeRegister(REG_OP_MODE, MODE_LONG_RANGE_MODE | MODE_TX);
 

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -712,9 +712,9 @@ bool LoRaClass::resetModem()
       REG_HOP_PERIOD, 0x00,
       REG_MODEM_CONFIG_3, 0x04,
       REG_PPM_CORRECTION, 0x00,
-      //REG_DETECTION_OPTIMIZE, 0xc3, // Errata says this needs to be set before REG_IF_FREQ_1 and REG_IF_FREQ_2
-      //REG_IF_FREQ_2, 0x45, // Datasheet says this defaults to 0x20, but dumping says 0x45.
-      //REG_IF_FREQ_1, 0x55, // Datasheet says this defaults to 0x00, but dumping says 0x55.
+      REG_DETECTION_OPTIMIZE, 0xc3, // Errata says this needs to be set before REG_IF_FREQ_1 and REG_IF_FREQ_2
+      REG_IF_FREQ_2, 0x45, // Datasheet says this defaults to 0x20, but dumping says 0x45.
+      REG_IF_FREQ_1, 0x55, // Datasheet says this defaults to 0x00, but dumping says 0x55.
       REG_INVERT_IQ, 0x27,
       REG_HIGH_BW_OPTIMIZE_1, 0x03,
       REG_DETECTION_THRESHOLD, 0x0a,

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -186,10 +186,7 @@ void LoRaClass::end()
   // stop SPI
   SPI.end();
 #elif LIBRARY_TYPE == LIBRARY_C
-  if (_fd >= 0) {
-    close(_fd);
-    _fd = -1;
-  }
+  // Don't do anything. We need to keep things open for restart. 
 #endif
   _spiBegun = false;
 }

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -125,8 +125,10 @@ int LoRaClass::begin(long frequency)
   // start SPI
   SPI.begin();
 #elif LIBRARY_TYPE == LIBRARY_C
-  _fd = open("/dev/spidev0.0", O_RDWR);
-  if (_fd < 0) {
+  const char* spi_filename = "/dev/spidev0.0";
+  std::cerr << "Opening SPI device " << spi_filename << std::endl;
+  _fd = open(spi_filename, O_RDWR);
+  if (_fd <= 0) {
     perror("could not open SPI device");
     exit(1);
   }
@@ -702,6 +704,8 @@ uint8_t ISR_VECT LoRaClass::singleTransfer(uint8_t address, uint8_t value)
   // In Linux, chip select is automatically turned off outside of transactions.
   
   int status;
+  
+  std::cerr << "Access SPI at " << _fd << std::endl;
   
   // Configure SPI speed and mode to match settings
   status = ioctl(_fd, SPI_IOC_WR_MODE, &_spiSettings.mode);

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -207,7 +207,7 @@ int LoRaClass::endPacket()
 #if LIBRARY_TYPE == LIBRARY_ARDUINO
     yield();
 #elif LIBRARY_TYPE == LIBRARY_C
-    ::sleep(1);
+    ::sleep(0);
 #endif
   }
 

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -78,6 +78,8 @@
 #define REG_VERSION              0x42
 #define REG_TXCO                 0x4B
 #define REG_PA_DAC               0x4D
+// These registers have different values in high and low frequency modes (flag 0x08 in mode)
+// We always stay in high frequency mode (flag is 0)
 #define REG_AGC_REF              0x61
 #define REG_AGC_THRESHOLD_1      0x62
 #define REG_AGC_THRESHOLD_2      0x63
@@ -714,12 +716,13 @@ bool LoRaClass::resetModem()
       REG_INVERT_IQ_2, 0x1d,
       REG_TXCO, 0x09,
       REG_PA_DAC, 0x84,
-      REG_AGC_REF, 0x1C, // Datasheet says this defaults to 0x13, but dumping says 0x1c.
+      // These are the high frequency mode (mode flag 0x08 is 0) values
+      REG_AGC_REF, 0x1C,
       REG_AGC_THRESHOLD_1, 0x0e,
       REG_AGC_THRESHOLD_2, 0x5b,
-      REG_AGC_THRESHOLD_3, 0xcc, // Datasheet says this defaults to 0xdb, but dumping says 0xcc.
+      REG_AGC_THRESHOLD_3, 0xcc,
       REG_PLL, 0xd0,
-      0, 0;
+      0, 0
     };
 
 

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -6,24 +6,6 @@
 
 #include "LoRa.h"
 
-#define MCU_1284P 0x91
-#define MCU_2560  0x92
-#define MCU_ESP32 0x81
-#if defined(__AVR_ATmega1284P__)
-  #define PLATFORM PLATFORM_AVR
-  #define MCU_VARIANT MCU_1284P
-#elif defined(__AVR_ATmega2560__)
-  #define PLATFORM PLATFORM_AVR
-  #define MCU_VARIANT MCU_2560
-#elif defined(ESP32)
-  #define PLATFORM PLATFORM_ESP32
-  #define MCU_VARIANT MCU_ESP32
-#endif
-
-#ifndef MCU_VARIANT
-  #error No MCU variant defined, cannot compile
-#endif
-
 #if MCU_VARIANT == MCU_ESP32
   #include "soc/rtc_wdt.h"
   #define ISR_VECT IRAM_ATTR

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -735,7 +735,6 @@ uint8_t ISR_VECT LoRaClass::singleTransfer(uint8_t address, uint8_t value)
   
   int status;
   
-  std::cerr << "Access SPI at " << _fd << std::endl;
   if (_fd <= 0) {
     throw std::runtime_error("Accessing SPI device without begin()!");
   }

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -215,13 +215,6 @@ int LoRaClass::beginPacket(int implicitHeader)
 
 int LoRaClass::endPacket()
 {
-#if LIBRARY_TYPE == LIBRARY_C
-  std::cerr << "Entering transmit mode" << std::endl;
-  for (uint8_t i = REG_OP_MODE ; i <= REG_PA_DAC; i++) {
-    uint8_t val = readRegister(i);
-    std::cerr << std::hex << "0x" << (int)i << " 0x" << (int)val << std::dec << std::endl;
-  }
-#endif
   // put in TX mode
   writeRegister(REG_OP_MODE, MODE_LONG_RANGE_MODE | MODE_TX);
 

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -215,7 +215,7 @@ int LoRaClass::beginPacket(int implicitHeader)
 
 int LoRaClass::endPacket()
 {
-#elif LIBRARY_TYPE == LIBRARY_C
+#if LIBRARY_TYPE == LIBRARY_C
   std::cerr << "Entering transmit mode" << std::endl;
   for (uint8_t i = REG_OP_MODE ; i <= REG_PA_DAC; i++) {
     uint8_t val = readRegister(i);

--- a/LoRa.h
+++ b/LoRa.h
@@ -15,7 +15,25 @@
 #elif LIBRARY_TYPE == LIBRARY_C
     #include <cstdlib>
     #include <cstdint>
-    #include "ArduinoOnLinux/Stream.h"
+    #include <iostream>
+    
+    // Arduino Stream is not available, but not actually needed.
+    class Stream {};
+    
+    typedef unsigned char byte;
+    
+    // Arduino SPI is not available.
+    #define MSBFIRST 0
+    #define SPI_MODE0 0
+    class SPISettings {
+    public:
+      inline SPISettings(int frequency, int bitness, int mode) : frequency(frequency), bitness(bitness), mode(mode) {};
+      SPISettings& operator=(const SPISettings& other) = default;
+      int frequency;
+      int bitness;
+      int mode;
+    };
+    
 #endif
 
 #define LORA_DEFAULT_SS_PIN    10
@@ -81,8 +99,12 @@ public:
 
   void setPins(int ss = LORA_DEFAULT_SS_PIN, int reset = LORA_DEFAULT_RESET_PIN, int dio0 = LORA_DEFAULT_DIO0_PIN);
   void setSPIFrequency(uint32_t frequency);
-
+  
+#if LIBRARY_TYPE == LIBRARY_ARDUINO
   void dumpRegisters(Stream& out);
+#elif LIBRARY_TYPE == LIBRARY_C
+  void dumpRegisters(std::ostream& out);
+#endif
 
 private:
   void explicitHeaderMode();
@@ -107,6 +129,9 @@ private:
   int _packetIndex;
   int _implicitHeaderMode;
   void (*_onReceive)(int);
+  #if LIBRARY_TYPE == LIBRARY_C
+    int _fd;
+  #endif
 };
 
 extern LoRaClass LoRa;

--- a/LoRa.h
+++ b/LoRa.h
@@ -22,16 +22,20 @@
     
     typedef unsigned char byte;
     
-    // Arduino SPI is not available.
+    // Arduino SPI is not available, so make a Linux-ish version of SPISettings
     #define MSBFIRST 0
-    #define SPI_MODE0 0
+    #define LSBFIRST 1
+    #define SPI_MODE0 SPI_MODE_0
+    #define SPI_MODE1 SPI_MODE_1
+    #define SPI_MODE2 SPI_MODE_2
+    #define SPI_MODE3 SPI_MODE_3
     class SPISettings {
     public:
-      inline SPISettings(int frequency, int bitness, int mode) : frequency(frequency), bitness(bitness), mode(mode) {};
+      inline SPISettings(uint32_t frequency, byte bitness, byte mode) : frequency(frequency), bitness(bitness), mode(mode) {};
       SPISettings& operator=(const SPISettings& other) = default;
-      int frequency;
-      int bitness;
-      int mode;
+      uint32_t frequency;
+      byte bitness;
+      byte mode;
     };
     
 #endif

--- a/LoRa.h
+++ b/LoRa.h
@@ -76,6 +76,7 @@ public:
   virtual int peek();
   virtual void flush();
 
+  void pollReceive();
   void onReceive(void(*callback)(int));
 
   void receive(int size = 0);
@@ -115,6 +116,7 @@ private:
   void implicitHeaderMode();
 
   void handleDio0Rise();
+  void handleRx();
 
   uint8_t readRegister(uint8_t address);
   void writeRegister(uint8_t address, uint8_t value);

--- a/LoRa.h
+++ b/LoRa.h
@@ -133,6 +133,7 @@ private:
   int _packetIndex;
   int _implicitHeaderMode;
   void (*_onReceive)(int);
+  bool _spiBegun;
   #if LIBRARY_TYPE == LIBRARY_C
     int _fd;
   #endif

--- a/LoRa.h
+++ b/LoRa.h
@@ -112,6 +112,8 @@ public:
 #endif
 
 private:
+  bool resetModem();
+
   void explicitHeaderMode();
   void implicitHeaderMode();
 

--- a/LoRa.h
+++ b/LoRa.h
@@ -7,8 +7,16 @@
 #ifndef LORA_H
 #define LORA_H
 
-#include <Arduino.h>
-#include <SPI.h>
+#include "Platform.h"
+
+#if LIBRARY_TYPE == LIBRARY_ARDUINO
+    #include <Arduino.h>
+    #include <SPI.h>
+#elif LIBRARY_TYPE == LIBRARY_C
+    #include <cstdlib>
+    #include <cstdint>
+    #include "ArduinoOnLinux/Stream.h"
+#endif
 
 #define LORA_DEFAULT_SS_PIN    10
 #define LORA_DEFAULT_RESET_PIN 9

--- a/MD5.cpp
+++ b/MD5.cpp
@@ -1,7 +1,7 @@
 #include "MD5.h"
 
 #if LIBRARY_TYPE == LIBRARY_ARDUINO
-    #include "Arduino.h"
+    #include <Arduino.h>
 #elif LIBRARY_TYPE == LIBRARY_C
     #include <cstdlib>
 #endif

--- a/MD5.cpp
+++ b/MD5.cpp
@@ -1,5 +1,11 @@
 #include "MD5.h"
 
+#if LIBRARY_TYPE == LIBRARY_ARDUINO
+    #include "Arduino.h"
+#elif LIBRARY_TYPE == LIBRARY_C
+    #include <cstdlib>
+#endif
+
 MD5::MD5()
 {
 	//nothing

--- a/MD5.h
+++ b/MD5.h
@@ -1,7 +1,13 @@
 #ifndef MD5_h
 #define MD5_h
 
-#include "Arduino.h"
+#include "Config.h"
+
+#if LIBRARY_TYPE == LIBRARY_ARDUINO
+    #include "Arduino.h"
+#elif LIBRARY_TYPE == LIBRARY_C
+    #include <cstdlib>
+#endif
 
 /*
  * This is an OpenSSL-compatible implementation of the RSA Data Security,

--- a/MD5.h
+++ b/MD5.h
@@ -1,13 +1,7 @@
 #ifndef MD5_h
 #define MD5_h
 
-#include "Config.h"
-
-#if LIBRARY_TYPE == LIBRARY_ARDUINO
-    #include "Arduino.h"
-#elif LIBRARY_TYPE == LIBRARY_C
-    #include <cstdlib>
-#endif
+#include "Platform.h"
 
 /*
  * This is an OpenSSL-compatible implementation of the RSA Data Security,

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,9 @@ clean:
 	rm -Rf bin
 	rm -Rf obj
 	
-obj/MD5.o: MD5.cpp MD5.h Config.h ROM.h prep-linux
+obj/MD5.o: MD5.cpp MD5.h Config.h ROM.h Platform.h prep-linux
+	$(CC) -c -o $@ $<
+	
+obj/LoRa.o: LoRa.cpp LoRa.h Platform.h prep-linux
 	$(CC) -c -o $@ $<
 	

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ prep-samd:
 	arduino-cli core update-index --config-file arduino-cli.yaml
 	arduino-cli core install adafruit:samd
 
+prep-linux:
+	mkdir -p bin
+	mkdir -p obj
 
 
 firmware:
@@ -135,3 +138,13 @@ release-mega2560:
 	arduino-cli compile --fqbn arduino:avr:mega -e
 	cp build/arduino.avr.mega/RNode_Firmware.ino.hex Release/rnode_firmware_latest_m2560.hex
 	rm -r build
+    
+.PHONY: clean prep-linux
+
+clean:
+	rm -Rf bin
+	rm -Rf obj
+	
+obj/MD5.o: MD5.cpp MD5.h Config.h ROM.h prep-linux
+	$(CC) -c -o $@ $<
+	

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,6 @@ prep-samd:
 	arduino-cli core update-index --config-file arduino-cli.yaml
 	arduino-cli core install adafruit:samd
 
-prep-linux:
-	mkdir -p bin
-	mkdir -p obj
-
-
 firmware:
 	arduino-cli compile --fqbn unsignedio:avr:rnode
 
@@ -139,18 +134,22 @@ release-mega2560:
 	cp build/arduino.avr.mega/RNode_Firmware.ino.hex Release/rnode_firmware_latest_m2560.hex
 	rm -r build
     
-.PHONY: clean prep-linux
-
 clean:
 	rm -Rf bin
 	rm -Rf obj
 	
-obj/MD5.o: MD5.cpp MD5.h Config.h ROM.h Platform.h prep-linux
+obj/MD5.o: MD5.cpp MD5.h Platform.h
+	mkdir -p obj
 	$(CC) -c -o $@ $<
 	
-obj/LoRa.o: LoRa.cpp LoRa.h Platform.h prep-linux
+obj/LoRa.o: LoRa.cpp LoRa.h Platform.h
+	mkdir -p obj
 	$(CC) -c -o $@ $<
 	
-obj/RNode_firmware.o: RNode_firmware.ino Utilities.h Config.h LoRa.h ROM.h Framing.h MD5.h Platform.h prep-linux
-	$(CC) -c -o $@ $<
+obj/RNode_Firmware.o: RNode_Firmware.ino Utilities.h Config.h LoRa.h ROM.h Framing.h MD5.h Platform.h
+	mkdir -p obj
+	$(CC) -c -o $@ -x c++ $<
 	
+bin/rnode: obj/RNode_Firmware.o obj/LoRa.o obj/MD5.o
+	mkdir -p bin
+	$(CC) -o $@ $^ -lstdc++

--- a/Makefile
+++ b/Makefile
@@ -152,4 +152,4 @@ obj/RNode_Firmware.o: RNode_Firmware.ino Utilities.h Config.h LoRa.h ROM.h Frami
 	
 bin/rnode: obj/RNode_Firmware.o obj/LoRa.o obj/MD5.o
 	mkdir -p bin
-	$(CC) -o $@ $^ -lstdc++
+	$(CC) -o $@ $^ -lstdc++ -lutil

--- a/Makefile
+++ b/Makefile
@@ -137,19 +137,21 @@ release-mega2560:
 clean:
 	rm -Rf bin
 	rm -Rf obj
-	
+
+CFLAGS += -g
+
 obj/MD5.o: MD5.cpp MD5.h Platform.h
 	mkdir -p obj
-	$(CC) -c -o $@ $<
+	$(CC) $(CFLAGS) -c -o $@ $<
 	
 obj/LoRa.o: LoRa.cpp LoRa.h Platform.h
 	mkdir -p obj
-	$(CC) -c -o $@ $<
+	$(CC) $(CFLAGS) -c -o $@ $<
 	
 obj/RNode_Firmware.o: RNode_Firmware.ino Utilities.h Config.h LoRa.h ROM.h Framing.h MD5.h Platform.h
 	mkdir -p obj
-	$(CC) -c -o $@ -x c++ $<
+	$(CC) $(CFLAGS) -c -o $@ -x c++ $<
 	
 bin/rnode: obj/RNode_Firmware.o obj/LoRa.o obj/MD5.o
 	mkdir -p bin
-	$(CC) -o $@ $^ -lstdc++ -lutil
+	$(CC) $(CFLAGS) -o $@ $^ -lstdc++ -lutil

--- a/Makefile
+++ b/Makefile
@@ -151,3 +151,6 @@ obj/MD5.o: MD5.cpp MD5.h Config.h ROM.h Platform.h prep-linux
 obj/LoRa.o: LoRa.cpp LoRa.h Platform.h prep-linux
 	$(CC) -c -o $@ $<
 	
+obj/RNode_firmware.o: RNode_firmware.ino Utilities.h Config.h LoRa.h ROM.h Framing.h MD5.h Platform.h prep-linux
+	$(CC) -c -o $@ $<
+	

--- a/Platform.h
+++ b/Platform.h
@@ -1,0 +1,42 @@
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+// Determine the platform, MCU, and C library we are building for.
+
+#define PLATFORM_AVR   0x90
+#define PLATFORM_ESP32 0x80
+#define PLATFORM_LINUX 0x70
+
+#define MCU_1284P 0x91
+#define MCU_2560  0x92
+#define MCU_ESP32 0x81
+#define MCU_LINUX 0x71
+
+#define LIBRARY_ARDUINO     0x1
+#define LIBRARY_C           0x2
+
+#if defined(__AVR_ATmega1284P__)
+    #define PLATFORM PLATFORM_AVR
+    #define MCU_VARIANT MCU_1284P
+    #define LIBRARY_TYPE LIBRARY_ARDUINO
+#elif defined(__AVR_ATmega2560__)
+    #define PLATFORM PLATFORM_AVR
+    #define MCU_VARIANT MCU_2560
+    #define LIBRARY_TYPE LIBRARY_ARDUINO
+#elif defined(ESP32)
+    #define PLATFORM PLATFORM_ESP32
+    #define MCU_VARIANT MCU_ESP32
+    #define LIBRARY_TYPE LIBRARY_ARDUINO
+#elif defined(__unix__)
+    #define PLATFORM PLATFORM_LINUX
+    #define MCU_VARIANT MCU_LINUX
+    #define LIBRARY_TYPE LIBRARY_C
+#else
+    #error "The firmware cannot be compiled for the selected MCU variant"
+#endif
+
+#ifndef MCU_VARIANT
+  #error No MCU variant defined, cannot compile
+#endif
+
+#endif

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -792,20 +792,9 @@ void validateStatus() {
   }
 }
 
-bool started = false;
-
 void loop() {
   if (radio_online) {
     checkModemStatus();
-
-    if (!started) {
-      started = true;
-      //promisc = true;
-      tbuf[0] = 'R';
-      tbuf[1] = 'N';
-      transmit(2);
-      //promisc = false;
-    }
 
     #if MCU_VARIANT == MCU_ESP32
       if (packet_ready) {

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -864,3 +864,12 @@ void serial_interrupt_init() {
     buffer_serial();
   }
 #endif
+
+#if PLATFORM == PLATFORM_LINUX
+  int main(int argc, char** argv) {
+    setup();
+    while (true) {
+      loop();
+    }
+  }
+#endif

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -151,6 +151,9 @@ inline void getPacketData(uint16_t len) {
 }
 
 void ISR_VECT receive_callback(int packet_size) {
+#if LIBRARY_TYPE == LIBRARY_C
+    std::cerr << "Got packet of " << packet_size << " bytes" << std::endl;
+#endif
   if (!promisc) {
     // The standard operating mode allows large
     // packets with a payload up to 500 bytes,
@@ -165,6 +168,11 @@ void ISR_VECT receive_callback(int packet_size) {
       // This is the first part of a split
       // packet, so we set the seq variable
       // and add the data to the buffer
+
+#if LIBRARY_TYPE == LIBRARY_C
+      std::cerr << "\tIs first part of split packet" << std::endl;
+#endif
+
       read_len = 0;
       seq = sequence;
 
@@ -179,7 +187,11 @@ void ISR_VECT receive_callback(int packet_size) {
       // This is the second part of a split
       // packet, so we add it to the buffer
       // and set the ready flag.
-      
+
+#if LIBRARY_TYPE == LIBRARY_C
+      std::cerr << "\tIs second part of split packet" << std::endl;
+#endif
+
       #if MCU_VARIANT != MCU_ESP32
         last_rssi = (last_rssi+LoRa.packetRssi())/2;
         last_snr_raw = (last_snr_raw+LoRa.packetSnrRaw())/2;
@@ -194,6 +206,11 @@ void ISR_VECT receive_callback(int packet_size) {
       // same sequence id, so we must assume
       // that we are seeing the first part of
       // a new split packet.
+
+#if LIBRARY_TYPE == LIBRARY_C
+      std::cerr << "\tIs first part of a different split packet" << std::endl;
+#endif
+
       read_len = 0;
       seq = sequence;
 
@@ -208,6 +225,10 @@ void ISR_VECT receive_callback(int packet_size) {
       // This is not a split packet, so we
       // just read it and set the ready
       // flag to true.
+
+#if LIBRARY_TYPE == LIBRARY_C
+      std::cerr << "\tIs complete packet" << std::endl;
+#endif
 
       if (seq != SEQ_UNSET) {
         // If we already had part of a split
@@ -368,6 +389,9 @@ void flushQueue(void) {
 void transmit(uint16_t size) {
   if (radio_online) {
     if (!promisc) {
+#if LIBRARY_TYPE == LIBRARY_C
+      std::cerr << "Sending RNode packet(s) of " << size << " bytes" << std::endl;
+#endif
       led_tx_on();
       uint16_t  written = 0;
       uint8_t header  = random(256) & 0xF0;
@@ -400,6 +424,11 @@ void transmit(uint16_t size) {
       // In promiscuous mode, we only send out
       // plain raw LoRa packets with a maximum
       // payload of 255 bytes
+
+#if LIBRARY_TYPE == LIBRARY_C
+      std::cerr << "Sending standard packet of " << size << " bytes" << std::endl;
+#endif
+
       led_tx_on();
       uint16_t  written = 0;
       

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -778,6 +778,12 @@ void loop() {
         kiss_write_packet();
       }
     #endif
+    
+    #if MCU_VARIANT == MCU_LINUX
+      // We don't have interrupts, so we need to poll ofr received packets.
+      // TODO: Is this fast enough? Or do we need threads or something?
+      LoRa.pollReceive(); 
+    #endif
 
     if (queue_height > 0) {
       if (!dcd_waiting) updateModemStatus();

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -792,9 +792,20 @@ void validateStatus() {
   }
 }
 
+bool started = false;
+
 void loop() {
   if (radio_online) {
     checkModemStatus();
+
+    if (!started) {
+      started = true;
+      //promisc = true;
+      tbuf[0] = 'R';
+      tbuf[1] = 'N';
+      transmit(2);
+      //promisc = false;
+    }
 
     #if MCU_VARIANT == MCU_ESP32
       if (packet_ready) {

--- a/Utilities.h
+++ b/Utilities.h
@@ -1,10 +1,87 @@
-#include <EEPROM.h>
+#if LIBRARY_TYPE == LIBRARY_ARDUINO
+  #include <EEPROM.h>
+#endif
 #include <stddef.h>
 #include "Config.h"
 #include "LoRa.h"
 #include "ROM.h"
 #include "Framing.h"
 #include "MD5.h"
+
+#if LIBRARY_TYPE == LIBRARY_C
+  #include <time.h>
+  // We need a delay()
+  void delay(int ms) {
+    struct timespec interval;
+    interval.tv_sec = ms / 1000;
+    interval.tv_nsec = (ms % 1000) * 1000 * 1000;
+    // TODO: handle signals interrupting sleep
+    nanosleep(&interval, NULL);
+  }
+  
+  // And millis()
+  struct timespec millis_base;
+  uint32_t millis() {
+    // Time since first call is close enough.
+    static bool base_set(false);
+    if (!base_set) {
+      if (clock_gettime(CLOCK_MONOTONIC, &millis_base)) {
+        exit(1);
+      }
+      base_set = true;
+    }
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now)) {
+      exit(1);
+    }
+    return (now.tv_sec - millis_base.tv_sec) * 1000 + (now.tv_nsec - millis_base.tv_nsec)/(1000*1000);
+  }
+  
+  // We also need a Serial
+  class SerialClass {
+  public:
+    const char* fifoPath = "rnode_socket";
+    void begin(int baud) {
+      int status = mkfifo(fifoPath, 0666);
+      if (status) {
+        perror("Making fifo failed");
+        exit(1);
+      }
+      // TODO: Need a bidirectional thing here: openpty???
+      _fd = open(fifoPath, O_RDWR);
+      if (_fd < 0) {
+        perror("could not open fifo");
+        exit(1);
+      }
+    }
+    // Be truthy if connected
+    operator bool() {
+      return _fd > 0; 
+    }
+    void write(int b) {
+      ssize_t written = ::write(_fd, 
+    }
+    void write(const char* data) {
+      throw std::runtime_error("Unimplemented");
+    }
+    bool available() {
+      throw std::runtime_error("Unimplemented");
+    }
+    uint8_t read() {
+      throw std::runtime_error("Unimplemented");
+    }
+  protected:
+    int _fd = -1;
+  };
+  SerialClass Serial;
+  
+  // And random(below);
+  int random(int below) {
+    return rand() % below;
+  }
+  
+  
+#endif
 
 #if MCU_VARIANT == MCU_ESP32
   #include "soc/rtc_wdt.h"
@@ -68,7 +145,15 @@ uint8_t boot_vector = 0x00;
 		void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
 		void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
 		void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
-	#endif
+  #endif
+#elif MCU_VARIANT == MCU_LINUX
+  #if BOARD_MODEL == BOARD_SPIDEV
+    // No LEDs on this board. SPI only.
+    void led_rx_on()  { }
+		void led_rx_off() { }
+		void led_tx_on()  { }
+		void led_tx_off() { }
+  #endif
 #endif
 
 void hard_reset(void) {
@@ -79,23 +164,27 @@ void hard_reset(void) {
 		}
 	#elif MCU_VARIANT == MCU_ESP32
 		ESP.restart();
+  #elif MCU_VARIANT == MCU_LINUX
+    // TODO: re-exec ourselves?
+    // For now just quit.
+    exit(0);
 	#endif
 }
 
 void led_indicate_error(int cycles) {
 	bool forever = (cycles == 0) ? true : false;
 	cycles = forever ? 1 : cycles;
-	while(cycles > 0) {
-        digitalWrite(pin_led_rx, HIGH);
-        digitalWrite(pin_led_tx, LOW);
-        delay(100);
-        digitalWrite(pin_led_rx, LOW);
-        digitalWrite(pin_led_tx, HIGH);
-        delay(100);
-        if (!forever) cycles--;
-    }
-    led_rx_off();
+	while(cycles > 0) { 
+    led_rx_on();
     led_tx_off();
+    delay(100);
+    led_rx_off();
+    led_tx_on();
+    delay(100);
+    if (!forever) cycles--;
+  }
+  led_rx_off();
+  led_tx_off();
 }
 
 void led_indicate_boot_error() {
@@ -112,7 +201,7 @@ void led_indicate_boot_error() {
 void led_indicate_warning(int cycles) {
 	bool forever = (cycles == 0) ? true : false;
 	cycles = forever ? 1 : cycles;
-	digitalWrite(pin_led_tx, HIGH);
+	led_tx_on();
 	while(cycles > 0) {
         led_tx_off();
         delay(100);
@@ -123,7 +212,7 @@ void led_indicate_warning(int cycles) {
    led_tx_off();
 }
 
-#if MCU_VARIANT == MCU_1284P || MCU_VARIANT == MCU_2560
+#if MCU_VARIANT == MCU_1284P || MCU_VARIANT == MCU_2560 || MCU_VARIANT == MCU_LINUX
 	void led_indicate_info(int cycles) {
 		bool forever = (cycles == 0) ? true : false;
 		cycles = forever ? 1 : cycles;
@@ -179,8 +268,9 @@ void led_indicate_warning(int cycles) {
 	#endif
 #endif
 
-
-unsigned long led_standby_ticks = 0;
+#if MCU_VARIANT == MCU_1284P || MCU_VARIANT == MCU_2560 || MCU_VARIANT == MCU_ESP32
+  unsigned long led_standby_ticks = 0;
+#endif
 #if MCU_VARIANT == MCU_1284P || MCU_VARIANT == MCU_2560
 	uint8_t led_standby_min = 1;
 	uint8_t led_standby_max = 40;
@@ -196,8 +286,10 @@ unsigned long led_standby_ticks = 0;
 	unsigned long led_standby_wait = 1768;
 	unsigned long led_notready_wait = 150;
 #endif
-uint8_t led_standby_value = led_standby_min;
-int8_t  led_standby_direction = 0;
+#if MCU_VARIANT == MCU_1284P || MCU_VARIANT == MCU_2560 || MCU_VARIANT == MCU_ESP32
+  uint8_t led_standby_value = led_standby_min;
+  int8_t  led_standby_direction = 0;
+#endif
 
 #if MCU_VARIANT == MCU_1284P || MCU_VARIANT == MCU_2560
 	void led_indicate_standby() {
@@ -243,6 +335,9 @@ int8_t  led_standby_direction = 0;
 			#endif
 		}
 	}
+#elif MCU_VARIANT == MCU_LINUX
+  // No LEDs available.
+  void led_indicate_standby() {}
 #endif
 
 #if MCU_VARIANT == MCU_1284P || MCU_VARIANT == MCU_2560
@@ -289,6 +384,9 @@ int8_t  led_standby_direction = 0;
 			#endif
 		}
 	}
+#elif MCU_VARIANT == MCU_LINUX
+  // No LEDs available.
+  void led_indicate_not_ready() {}
 #endif
 
 void escapedSerialWrite(uint8_t byte) {
@@ -551,41 +649,21 @@ void promisc_disable() {
 	promisc = false;
 }
 
+uint8_t eeprom_read(uint8_t addr) {
+  #if MCU_VARIANT == MCU_LINUX
+    return 0;
+  #else
+    return EEPROM.read(eeprom_addr(addr));
+  #endif
+}
+
 bool eeprom_info_locked() {
-	uint8_t lock_byte = EEPROM.read(eeprom_addr(ADDR_INFO_LOCK));
+	uint8_t lock_byte = eeprom_read(ADDR_INFO_LOCK);
 	if (lock_byte == INFO_LOCK_BYTE) {
 		return true;
 	} else {
 		return false;
 	}
-}
-
-void eeprom_dump_info() {
-	for (int addr = ADDR_PRODUCT; addr <= ADDR_INFO_LOCK; addr++) {
-		uint8_t byte = EEPROM.read(eeprom_addr(addr));
-		escapedSerialWrite(byte);
-	}
-}
-
-void eeprom_dump_config() {
-	for (int addr = ADDR_CONF_SF; addr <= ADDR_CONF_OK; addr++) {
-		uint8_t byte = EEPROM.read(eeprom_addr(addr));
-		escapedSerialWrite(byte);
-	}
-}
-
-void eeprom_dump_all() {
-	for (int addr = 0; addr < EEPROM_RESERVED; addr++) {
-		uint8_t byte = EEPROM.read(eeprom_addr(addr));
-		escapedSerialWrite(byte);
-	}
-}
-
-void kiss_dump_eeprom() {
-	Serial.write(FEND);
-	Serial.write(CMD_ROM_READ);
-	eeprom_dump_all();
-	Serial.write(FEND);
 }
 
 void eeprom_update(int mapped_addr, uint8_t byte) {
@@ -597,7 +675,6 @@ void eeprom_update(int mapped_addr, uint8_t byte) {
 			EEPROM.commit();
 		}
 	#endif
-
 }
 
 void eeprom_write(uint8_t addr, uint8_t byte) {
@@ -615,16 +692,36 @@ void eeprom_erase() {
 	hard_reset();
 }
 
-bool eeprom_lock_set() {
-	if (EEPROM.read(eeprom_addr(ADDR_INFO_LOCK)) == INFO_LOCK_BYTE) {
-		return true;
-	} else {
-		return false;
+void eeprom_dump_info() {
+	for (int addr = ADDR_PRODUCT; addr <= ADDR_INFO_LOCK; addr++) {
+		uint8_t byte = eeprom_read(addr);
+		escapedSerialWrite(byte);
 	}
 }
 
+void eeprom_dump_config() {
+	for (int addr = ADDR_CONF_SF; addr <= ADDR_CONF_OK; addr++) {
+		uint8_t byte = eeprom_read(addr);
+		escapedSerialWrite(byte);
+	}
+}
+
+void eeprom_dump_all() {
+	for (int addr = 0; addr < EEPROM_RESERVED; addr++) {
+		uint8_t byte = eeprom_read(addr);
+		escapedSerialWrite(byte);
+	}
+}
+
+void kiss_dump_eeprom() {
+	Serial.write(FEND);
+	Serial.write(CMD_ROM_READ);
+	eeprom_dump_all();
+	Serial.write(FEND);
+}
+
 bool eeprom_product_valid() {
-	uint8_t rval = EEPROM.read(eeprom_addr(ADDR_PRODUCT));
+	uint8_t rval = eeprom_read(ADDR_PRODUCT);
 
 	#if PLATFORM == PLATFORM_AVR
 	if (rval == PRODUCT_RNODE || rval == PRODUCT_HMBRW) {
@@ -640,7 +737,7 @@ bool eeprom_product_valid() {
 }
 
 bool eeprom_model_valid() {
-	model = EEPROM.read(eeprom_addr(ADDR_MODEL));
+	model = eeprom_read(ADDR_MODEL);
 	#if BOARD_MODEL == BOARD_RNODE
 	if (model == MODEL_A4 || model == MODEL_A9) {
 	#elif BOARD_MODEL == BOARD_HMBRW
@@ -665,7 +762,7 @@ bool eeprom_model_valid() {
 }
 
 bool eeprom_hwrev_valid() {
-	hwrev = EEPROM.read(eeprom_addr(ADDR_HW_REV));
+	hwrev = eeprom_read(ADDR_HW_REV);
 	if (hwrev != 0x00 && hwrev != 0xFF) {
 		return true;
 	} else {
@@ -676,14 +773,14 @@ bool eeprom_hwrev_valid() {
 bool eeprom_checksum_valid() {
 	char *data = (char*)malloc(CHECKSUMMED_SIZE);
 	for (uint8_t  i = 0; i < CHECKSUMMED_SIZE; i++) {
-		char byte = EEPROM.read(eeprom_addr(i));
+		char byte = eeprom_read(i);
 		data[i] = byte;
 	}
 	
 	unsigned char *hash = MD5::make_hash(data, CHECKSUMMED_SIZE);
 	bool checksum_valid = true;
 	for (uint8_t i = 0; i < 16; i++) {
-		uint8_t stored_chk_byte = EEPROM.read(eeprom_addr(ADDR_CHKSUM+i));
+		uint8_t stored_chk_byte = eeprom_read(ADDR_CHKSUM+i);
 		uint8_t calced_chk_byte = (uint8_t)hash[i];
 		if (stored_chk_byte != calced_chk_byte) {
 			checksum_valid = false;
@@ -696,7 +793,7 @@ bool eeprom_checksum_valid() {
 }
 
 bool eeprom_have_conf() {
-	if (EEPROM.read(eeprom_addr(ADDR_CONF_OK)) == CONF_OK_BYTE) {
+	if (eeprom_read(ADDR_CONF_OK) == CONF_OK_BYTE) {
 		return true;
 	} else {
 		return false;
@@ -705,11 +802,11 @@ bool eeprom_have_conf() {
 
 void eeprom_conf_load() {
 	if (eeprom_have_conf()) {
-		lora_sf = EEPROM.read(eeprom_addr(ADDR_CONF_SF));
-		lora_cr = EEPROM.read(eeprom_addr(ADDR_CONF_CR));
-		lora_txp = EEPROM.read(eeprom_addr(ADDR_CONF_TXP));
-		lora_freq = (uint32_t)EEPROM.read(eeprom_addr(ADDR_CONF_FREQ)+0x00) << 24 | (uint32_t)EEPROM.read(eeprom_addr(ADDR_CONF_FREQ)+0x01) << 16 | (uint32_t)EEPROM.read(eeprom_addr(ADDR_CONF_FREQ)+0x02) << 8 | (uint32_t)EEPROM.read(eeprom_addr(ADDR_CONF_FREQ)+0x03);
-		lora_bw = (uint32_t)EEPROM.read(eeprom_addr(ADDR_CONF_BW)+0x00) << 24 | (uint32_t)EEPROM.read(eeprom_addr(ADDR_CONF_BW)+0x01) << 16 | (uint32_t)EEPROM.read(eeprom_addr(ADDR_CONF_BW)+0x02) << 8 | (uint32_t)EEPROM.read(eeprom_addr(ADDR_CONF_BW)+0x03);
+		lora_sf = eeprom_read(ADDR_CONF_SF);
+		lora_cr = eeprom_read(ADDR_CONF_CR);
+		lora_txp = eeprom_read(ADDR_CONF_TXP);
+		lora_freq = (uint32_t)eeprom_read(ADDR_CONF_FREQ+0x00) << 24 | (uint32_t)eeprom_read(ADDR_CONF_FREQ+0x01) << 16 | (uint32_t)eeprom_read(ADDR_CONF_FREQ+0x02) << 8 | (uint32_t)eeprom_read(ADDR_CONF_FREQ+0x03);
+		lora_bw = (uint32_t)eeprom_read(ADDR_CONF_BW+0x00) << 24 | (uint32_t)eeprom_read(ADDR_CONF_BW+0x01) << 16 | (uint32_t)eeprom_read(ADDR_CONF_BW+0x02) << 8 | (uint32_t)eeprom_read(ADDR_CONF_BW+0x03);
 	}
 }
 
@@ -784,7 +881,7 @@ inline void fifo_flush(FIFOBuffer *f) {
   f->head = f->tail;
 }
 
-#if MCU_VARIANT != MCU_ESP32
+#if SERIAL_EVENTS == SERIAL_INTERRUPT
 	static inline bool fifo_isempty_locked(const FIFOBuffer *f) {
 	  bool result;
 	  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
@@ -866,7 +963,7 @@ inline void fifo16_flush(FIFOBuffer16 *f) {
   f->head = f->tail;
 }
 
-#if MCU_VARIANT != MCU_ESP32
+#if SERIAL_EVENTS == SERIAL_INTERRUPT
 	static inline bool fifo16_isempty_locked(const FIFOBuffer16 *f) {
 	  bool result;
 	  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {


### PR DESCRIPTION
This is my first attempt at making the RNode firmware build for Linux.

I've tested this with my board where I have a HopeRF RFM95W on `/dev/spidev0.0`, with only SPI and no reset or DIO connections, and it seems to work. I can set an EEPROM with rnodeconf, and configure it as long as I have https://github.com/markqvist/rnodeconfigutil/pull/8 so it doesn't time out on the EEPROM dump.

Since there's no reset, I have code for Linux to set all the important registers at startup to the values that the rest of the code seems to be expecting to be working with. I got some of these from dumps with https://github.com/interfect/spi-lora/blob/master/lora_util.py; I try to note where what I get from the dump disagrees with what the datasheet says really ought to be there.

Since there's no DIO interrupts, I have code for Linux to poll the interrupt flags byte. This seems to be quick enough that I'm not seeing a lot of lost second parts of packets (except when the node decides to transmit its own packet while expecting the second part).

I've tested using `tncattach` to send IP packets back and forth. With `rnodeconf /dev/pts/3 -T --freq 903000000 --bw 250000 --txp 13 --sf 7 --cr 5` and then `sudo tncattach /dev/pts/3 115200 -e -n -m 478 -i 10.99.0.1/24` I'm getting a back-and-forth ping time of something like 500 ms, which seems long. Is that about what I should expect? The pings shouldn't be up anywhere near the ~10 kilobit bitrate I would expect to be able to get.

I *haven't* yet tested the Arduino build after all my changes; I still need to make sure the Makefile can build it, and ideally get an actual device to try it on.

This will fix #14.