### PR TITLE
Optimize receiver sensitivity, per errata note 2.1

### DIFF
--- a/LoRa.h
+++ b/LoRa.h
@@ -93,6 +93,7 @@ private:
   static void onDio0Rise();
 
   void handleLowDataRate();
+  void optimizeModemSensitivity();
 
 private:
   SPISettings _spiSettings;


### PR DESCRIPTION
According to Errata Note § 2.1 for the SX1276/77/78/79 series
> The following LoRa registers should be changed as described, for BW=500 kHz
>   - For carrier frequencies ranging from 862 to 1020 MHz
>     - Set LoRa register at address 0x36 to value 0x02 (by default 0x03)
>     - Set LoRa register at address 0x3a to value 0x64 (by default 0x65)
>   - For carrier frequencies ranging from 410 to 525 MHz
>     - Set LoRa register at address 0x36 to value 0x02 (by default 0x03)
>     - Set LoRa register at address 0x3a to value 0x7F (by default 0x65)
>
> For all other combinations of bandwidth / frequencies, register at address 0x36 should be re-set to value 0x03, and the value at address 0x3a will be automatically selected by the chip.

This commit does exactly that.
