### PR TITLE
Switch from old AXP202X_Library to new XPowersLib

### DIFF
--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -110,8 +110,16 @@ bool LoRaClass::preInit() {
   
   SPI.begin();
 
-  // check version
-  uint8_t version = readRegister(REG_VERSION);
+  // check version (retry for up to 2 seconds)
+  uint8_t version;
+  long start = millis();
+  while (((millis() - start) < 2000) && (millis() >= start)) {
+    version = readRegister(REG_VERSION);
+    if (version == 0x12) {
+      break;
+    }
+    delay(100);
+  }
   if (version != 0x12) {
     return false;
   }

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ prep-esp32:
 	arduino-cli core update-index --config-file arduino-cli.yaml
 	arduino-cli core install esp32:esp32
 	arduino-cli lib install "Adafruit SSD1306"
-	arduino-cli lib install "AXP202X_Library"
+	arduino-cli lib install "XPowersLib"
 	arduino-cli lib install "Crypto"
 
 prep-samd:

--- a/Power.h
+++ b/Power.h
@@ -1,14 +1,31 @@
 #if BOARD_MODEL == BOARD_TBEAM
-  #include <axp20x.h>
-  AXP20X_Class PMU;
+  #include <XPowersLib.h>
+  XPowersLibInterface* PMU = NULL;
+
+  #ifndef PMU_WIRE_PORT
+    #define PMU_WIRE_PORT   Wire
+  #endif
 
   #define BAT_V_MIN       3.15
   #define BAT_V_MAX       4.14
 
   void disablePeripherals() {
-    PMU.setPowerOutPut(AXP192_DCDC1, AXP202_OFF);
-    PMU.setPowerOutPut(AXP192_LDO2, AXP202_OFF);
-    PMU.setPowerOutPut(AXP192_LDO3, AXP202_OFF);
+    if (PMU) {
+      // GNSS RTC PowerVDD
+      PMU->enablePowerOutput(XPOWERS_VBACKUP);
+
+      // LoRa VDD
+      PMU->disablePowerOutput(XPOWERS_ALDO2);
+
+      // GNSS VDD
+      PMU->disablePowerOutput(XPOWERS_ALDO3);
+    }
+  }
+
+  bool pmuInterrupt;
+  void setPmuFlag()
+  {
+      pmuInterrupt = true;
   }
 #elif BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1
   #define BAT_C_SAMPLES   7
@@ -98,66 +115,84 @@ void measure_battery() {
     }
 
   #elif BOARD_MODEL == BOARD_TBEAM
-    float discharge_current = PMU.getBattDischargeCurrent();
-    float charge_current    = PMU.getBattChargeCurrent();
-    battery_voltage         = PMU.getBattVoltage()/1000.0;
-    // battery_percent         = PMU.getBattPercentage()*1.0;
-    battery_installed       = PMU.isBatteryConnect();
-    external_power          = PMU.isVBUSPlug();
-    float ext_voltage       = PMU.getVbusVoltage()/1000.0;
-    float ext_current       = PMU.getVbusCurrent();
+    if (PMU) {
+      float discharge_current = 0;
+      float charge_current    = 0;
+      float ext_voltage       = 0;
+      float ext_current       = 0;
+      if (PMU->getChipModel() == XPOWERS_AXP192) {
+        discharge_current       = ((XPowersAXP192*)PMU)->getBattDischargeCurrent();
+        charge_current          = ((XPowersAXP192*)PMU)->getBatteryChargeCurrent();
+        battery_voltage         = PMU->getBattVoltage()/1000.0;
+        // battery_percent         = PMU->getBattPercentage()*1.0;
+        battery_installed       = PMU->isBatteryConnect();
+        external_power          = PMU->isVbusIn();
+        ext_voltage             = PMU->getVbusVoltage()/1000.0;
+        ext_current             = ((XPowersAXP192*)PMU)->getVbusCurrent();
+      }
+      else if (PMU->getChipModel() == XPOWERS_AXP2101) {
+        battery_voltage         = PMU->getBattVoltage()/1000.0;
+        // battery_percent         = PMU->getBattPercentage()*1.0;
+        battery_installed       = PMU->isBatteryConnect();
+        external_power          = PMU->isVbusIn();
+        ext_voltage             = PMU->getVbusVoltage()/1000.0;
+      }
 
-    if (battery_installed) {
-      if (PMU.isChargeing()) {
-        battery_state = BATTERY_STATE_CHARGING;
-        battery_percent = ((battery_voltage-BAT_V_MIN) / (BAT_V_MAX-BAT_V_MIN))*100.0;
-      } else {
-        if (discharge_current > 0.0) {
-          battery_state = BATTERY_STATE_DISCHARGING;
+      if (battery_installed) {
+        if (PMU->isCharging()) {
+          battery_state = BATTERY_STATE_CHARGING;
           battery_percent = ((battery_voltage-BAT_V_MIN) / (BAT_V_MAX-BAT_V_MIN))*100.0;
         } else {
-          battery_state = BATTERY_STATE_CHARGED;
-          battery_percent = 100.0;
+          if (PMU->isDischarge()) {
+            battery_state = BATTERY_STATE_DISCHARGING;
+            battery_percent = ((battery_voltage-BAT_V_MIN) / (BAT_V_MAX-BAT_V_MIN))*100.0;
+          } else {
+            battery_state = BATTERY_STATE_CHARGED;
+            battery_percent = 100.0;
+          }
         }
+      } else {
+        battery_state = BATTERY_STATE_DISCHARGING;
+        battery_percent = 0.0;
+        battery_voltage = 0.0;
       }
-    } else {
-      battery_state = BATTERY_STATE_DISCHARGING;
-      battery_percent = 0.0;
-      battery_voltage = 0.0;
+
+      if (battery_percent > 100.0) battery_percent = 100.0;
+      if (battery_percent < 0.0) battery_percent = 0.0;
+
+      float charge_watts    = battery_voltage*(charge_current/1000.0);
+      float discharge_watts = battery_voltage*(discharge_current/1000.0);
+      float ext_watts       = ext_voltage*(ext_current/1000.0);
+
+      battery_ready = true;
+
+      // if (bt_state == BT_STATE_CONNECTED) {
+      //   if (battery_installed) {
+      //     if (external_power) {
+      //       SerialBT.printf("External power connected, drawing %.2fw, %.1fmA at %.1fV\n", ext_watts, ext_current, ext_voltage);
+      //     } else {
+      //       SerialBT.println("Running on battery");
+      //     }
+      //     SerialBT.printf("Battery percentage %.1f%%\n", battery_percent);
+      //     SerialBT.printf("Battery voltage %.2fv\n", battery_voltage);
+      //     // SerialBT.printf("Temperature %.1f%\n", auxillary_temperature);
+
+      //     if (battery_state == BATTERY_STATE_CHARGING) {
+      //       SerialBT.printf("Charging with %.2fw, %.1fmA at %.1fV\n", charge_watts, charge_current, battery_voltage);
+      //     } else if (battery_state == BATTERY_STATE_DISCHARGING) {
+      //       SerialBT.printf("Discharging at %.2fw, %.1fmA at %.1fV\n", discharge_watts, discharge_current, battery_voltage);
+      //     } else if (battery_state == BATTERY_STATE_CHARGED) {
+      //       SerialBT.printf("Battery charged\n");
+      //     }
+      //   } else {
+      //     SerialBT.println("No battery installed");
+      //   }
+      //   SerialBT.println("");
+      // }
     }
-
-    if (battery_percent > 100.0) battery_percent = 100.0;
-    if (battery_percent < 0.0) battery_percent = 0.0;
-
-    float charge_watts    = battery_voltage*(charge_current/1000.0);
-    float discharge_watts = battery_voltage*(discharge_current/1000.0);
-    float ext_watts       = ext_voltage*(ext_current/1000.0);
-
-    battery_ready = true;
-
-    // if (bt_state == BT_STATE_CONNECTED) {
-    //   if (battery_installed) {
-    //     if (external_power) {
-    //       SerialBT.printf("External power connected, drawing %.2fw, %.1fmA at %.1fV\n", ext_watts, ext_current, ext_voltage);
-    //     } else {
-    //       SerialBT.println("Running on battery");
-    //     }
-    //     SerialBT.printf("Battery percentage %.1f%%\n", battery_percent);
-    //     SerialBT.printf("Battery voltage %.2fv\n", battery_voltage);
-    //     // SerialBT.printf("Temperature %.1f%\n", auxillary_temperature);
-
-    //     if (battery_state == BATTERY_STATE_CHARGING) {
-    //       SerialBT.printf("Charging with %.2fw, %.1fmA at %.1fV\n", charge_watts, charge_current, battery_voltage);
-    //     } else if (battery_state == BATTERY_STATE_DISCHARGING) {
-    //       SerialBT.printf("Discharging at %.2fw, %.1fmA at %.1fV\n", discharge_watts, discharge_current, battery_voltage);
-    //     } else if (battery_state == BATTERY_STATE_CHARGED) {
-    //       SerialBT.printf("Battery charged\n");
-    //     }
-    //   } else {
-    //     SerialBT.println("No battery installed");
-    //   }
-    //   SerialBT.println("");
-    // }
+    else {
+      battery_ready = false;
+    }
   #endif
 
   if (battery_ready) {
@@ -181,48 +216,129 @@ bool init_pmu() {
     return true;
   #elif BOARD_MODEL == BOARD_TBEAM
     Wire.begin(I2C_SDA, I2C_SCL);
-    if (PMU.begin(Wire, AXP192_SLAVE_ADDRESS) == AXP_FAIL) return false;
+
+    if (!PMU) {
+        PMU = new XPowersAXP2101(PMU_WIRE_PORT);
+        if (!PMU->init()) {
+            Serial.println("Warning: Failed to find AXP2101 power management");
+            delete PMU;
+            PMU = NULL;
+        } else {
+            Serial.println("AXP2101 PMU init succeeded, using AXP2101 PMU");
+        }
+    }
+
+    if (!PMU) {
+        PMU = new XPowersAXP192(PMU_WIRE_PORT);
+        if (!PMU->init()) {
+            Serial.println("Warning: Failed to find AXP192 power management");
+            delete PMU;
+            PMU = NULL;
+        } else {
+            Serial.println("AXP192 PMU init succeeded, using AXP192 PMU");
+        }
+    }
+
+    if (!PMU) {
+        return false;
+    }
 
     // Configure charging indicator
-    PMU.setChgLEDMode(AXP20X_LED_OFF);
-
-    // Turn off unused power sources to save power
-    PMU.setPowerOutPut(AXP192_DCDC1, AXP202_OFF);
-    PMU.setPowerOutPut(AXP192_DCDC2, AXP202_OFF);
-    PMU.setPowerOutPut(AXP192_LDO2, AXP202_OFF);
-    PMU.setPowerOutPut(AXP192_LDO3, AXP202_OFF);
-    PMU.setPowerOutPut(AXP192_EXTEN, AXP202_OFF);
-
-    // Set the power of LoRa and GPS module to 3.3V
-    PMU.setLDO2Voltage(3300);   //LoRa VDD
-    PMU.setLDO3Voltage(3300);   //GPS  VDD
-    PMU.setDCDC1Voltage(3300);  //3.3V Pin next to 21 and 22 is controlled by DCDC1
-
-    PMU.setPowerOutPut(AXP192_DCDC1, AXP202_ON);
-
-    // Turn on SX1276
-    PMU.setPowerOutPut(AXP192_LDO2, AXP202_ON);
-
-    // Turn off GPS
-    PMU.setPowerOutPut(AXP192_LDO3, AXP202_OFF);
+    PMU->setChargingLedMode(XPOWERS_CHG_LED_OFF);
 
     pinMode(PMU_IRQ, INPUT_PULLUP);
-    attachInterrupt(PMU_IRQ, [] {
-      // pmu_irq = true;
-    }, FALLING);
+    attachInterrupt(PMU_IRQ, setPmuFlag, FALLING);
 
-    PMU.adc1Enable(AXP202_VBUS_VOL_ADC1 |
-                   AXP202_VBUS_CUR_ADC1 |
-                   AXP202_BATT_CUR_ADC1 |
-                   AXP202_BATT_VOL_ADC1,
-                   AXP202_ON);
+    if (PMU->getChipModel() == XPOWERS_AXP192) {
 
-    PMU.enableIRQ(AXP202_VBUS_REMOVED_IRQ |
-                  AXP202_VBUS_CONNECT_IRQ |
-                  AXP202_BATT_REMOVED_IRQ |
-                  AXP202_BATT_CONNECT_IRQ,
-                  AXP202_ON);
-    PMU.clearIRQ();
+      // Turn off unused power sources to save power
+      PMU->disablePowerOutput(XPOWERS_DCDC1);
+      PMU->disablePowerOutput(XPOWERS_DCDC2);
+      PMU->disablePowerOutput(XPOWERS_LDO2);
+      PMU->disablePowerOutput(XPOWERS_LDO3);
+
+      // Set the power of LoRa and GPS module to 3.3V
+      // LoRa
+      PMU->setPowerChannelVoltage(XPOWERS_LDO2, 3300);
+      // GPS
+      PMU->setPowerChannelVoltage(XPOWERS_LDO3, 3300);
+      // OLED
+      PMU->setPowerChannelVoltage(XPOWERS_DCDC1, 3300);
+
+      // Turn on LoRa
+      PMU->enablePowerOutput(XPOWERS_LDO2);
+
+      // Turn on GPS
+      //PMU->enablePowerOutput(XPOWERS_LDO3);
+
+      // protected oled power source
+      PMU->setProtectedChannel(XPOWERS_DCDC1);
+      // protected esp32 power source
+      PMU->setProtectedChannel(XPOWERS_DCDC3);
+      // enable oled power
+      PMU->enablePowerOutput(XPOWERS_DCDC1);
+
+      PMU->disableIRQ(XPOWERS_AXP192_ALL_IRQ);
+
+      PMU->enableIRQ(XPOWERS_AXP192_VBUS_REMOVE_IRQ |
+                      XPOWERS_AXP192_VBUS_INSERT_IRQ |
+                      XPOWERS_AXP192_BAT_CHG_DONE_IRQ |
+                      XPOWERS_AXP192_BAT_CHG_START_IRQ |
+                      XPOWERS_AXP192_BAT_REMOVE_IRQ |
+                      XPOWERS_AXP192_BAT_INSERT_IRQ |
+                      XPOWERS_AXP192_PKEY_SHORT_IRQ
+                    );
+
+    }
+    else if (PMU->getChipModel() == XPOWERS_AXP2101) {
+
+      // Turn off unused power sources to save power
+      PMU->disablePowerOutput(XPOWERS_DCDC2);
+      PMU->disablePowerOutput(XPOWERS_DCDC3);
+      PMU->disablePowerOutput(XPOWERS_DCDC4);
+      PMU->disablePowerOutput(XPOWERS_DCDC5);
+      PMU->disablePowerOutput(XPOWERS_ALDO1);
+      PMU->disablePowerOutput(XPOWERS_ALDO2);
+      PMU->disablePowerOutput(XPOWERS_ALDO3);
+      PMU->disablePowerOutput(XPOWERS_ALDO4);
+      PMU->disablePowerOutput(XPOWERS_BLDO1);
+      PMU->disablePowerOutput(XPOWERS_BLDO2);
+      PMU->disablePowerOutput(XPOWERS_DLDO1);
+      PMU->disablePowerOutput(XPOWERS_DLDO2);
+      PMU->disablePowerOutput(XPOWERS_VBACKUP);
+
+      // Set the power of LoRa and GPS module to 3.3V
+      // LoRa
+      PMU->setPowerChannelVoltage(XPOWERS_ALDO2, 3300);
+      // GPS
+      PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);
+      PMU->setPowerChannelVoltage(XPOWERS_VBACKUP, 3300);
+
+      // ESP32 VDD
+      // ! No need to set, automatically open , Don't close it
+      // PMU->setPowerChannelVoltage(XPOWERS_DCDC1, 3300);
+      // PMU->setProtectedChannel(XPOWERS_DCDC1);
+      PMU->setProtectedChannel(XPOWERS_DCDC1);
+
+      // LoRa VDD
+      PMU->enablePowerOutput(XPOWERS_ALDO2);
+
+      // GNSS VDD
+      //PMU->enablePowerOutput(XPOWERS_ALDO3);
+
+      // GNSS RTC PowerVDD
+      //PMU->enablePowerOutput(XPOWERS_VBACKUP);
+    }
+
+    PMU->enableSystemVoltageMeasure();
+    PMU->enableVbusVoltageMeasure();
+    PMU->enableBattVoltageMeasure();
+    // It is necessary to disable the detection function of the TS pin on the board
+    // without the battery temperature detection function, otherwise it will cause abnormal charging
+    PMU->disableTSPinMeasure();
+
+    // Set the time of pressing the button to turn off
+    PMU->setPowerKeyPressOffTime(XPOWERS_POWEROFF_4S);
 
     return true; 
   #else


### PR DESCRIPTION
This PR adds support for the newer v1.2 T-Beam boards which use the new AXP2101 PMU in place of the AXP192 PMU used in v1.1 boards. This fixes the issue where the v1.2 board hangs on radio access, and reports failure to start radio on power-cycle.

I attempted to keep AXP192 support as close as possible to what it was previoulsy, and to implement new AXP2101 support as closely as possible to AXP192. Some features appear to be missing though in the AXP2101 implementation (eg battery and vbus current measurements). It also wasn't clear how to disable the OLED at the PMU on the AXP2101 so I left that out for now.