### PR TITLE
Use /usr/bin/env python in partition_hashes

### DIFF
--- a/partition_hashes
+++ b/partition_hashes
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 # Copyright (C) 2023, Mark Qvist
 


### PR DESCRIPTION
By using `/usr/bin/env python` we ensure that we'll be selecting the correct Python version the user most likely expected to be used. The most common usecase for this is when Reticulum is installed in a virtual env.