### PR TITLE
Fix nRF52 compilation error

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -330,6 +330,7 @@
             const int pin_dio = 47;
             const int pin_led_rx = LED_BLUE;
             const int pin_led_tx = LED_GREEN;
+            const int pin_tcxo_enable = -1;
         #endif
 	#else
 		#error An unsupported board was selected. Cannot compile RNode firmware.

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -73,8 +73,10 @@ void setup() {
   #endif
 
   #if HAS_TCXO == true
-    pinMode(pin_tcxo_enable, OUTPUT);
-    digitalWrite(pin_tcxo_enable, HIGH);
+    if (pin_tcxo_enable != -1) {
+        pinMode(pin_tcxo_enable, OUTPUT);
+        digitalWrite(pin_tcxo_enable, HIGH);
+    }
   #endif
 
   // Initialise buffers


### PR DESCRIPTION
This is a short fix to fix an error, allowing the nRF52 variant to compile.
