### PR TITLE
**DRAFT** Heltec 32 V3

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -256,7 +256,7 @@
             #define HAS_EEPROM true
 		#elif BOARD_MODEL == BOARD_HELTEC32_V3
             #define HAS_EEPROM true
-            #define HAS_DISPLAY true // set for debugging
+            #define HAS_DISPLAY true
             #define HAS_BLUETOOTH false
             #define HAS_CONSOLE false
             #define HAS_PMU false

--- a/Config.h
+++ b/Config.h
@@ -255,7 +255,7 @@
             #define HAS_CONSOLE true
             #define HAS_EEPROM true
 		#elif BOARD_MODEL == BOARD_HELTEC32_V3
-            #define HAS_EEPROM false
+            #define HAS_EEPROM true
             #define HAS_DISPLAY false // set for debugging
             #define HAS_BLUETOOTH false
             #define HAS_CONSOLE false
@@ -376,7 +376,7 @@
     /*#if MODEM == SX1262
         SPIClass spiModem(NRF_SPIM2, pin_miso, pin_sclk, pin_mosi);
     #endif*/
-	
+
 	// MCU independent configuration parameters
 	const long serial_baudrate  = 115200;
 

--- a/Config.h
+++ b/Config.h
@@ -373,9 +373,9 @@
         const int pin_busy = -1;
     #endif
 
-    /*#if MODEM == SX1262
+    #if MODEM == SX1262 and defined(NRF52840_XXAA)
         SPIClass spiModem(NRF_SPIM2, pin_miso, pin_sclk, pin_mosi);
-    #endif*/
+    #endif
 
 	// MCU independent configuration parameters
 	const long serial_baudrate  = 115200;

--- a/Config.h
+++ b/Config.h
@@ -256,7 +256,7 @@
             #define HAS_EEPROM true
 		#elif BOARD_MODEL == BOARD_HELTEC32_V3
             #define HAS_EEPROM true
-            #define HAS_DISPLAY false // set for debugging
+            #define HAS_DISPLAY true // set for debugging
             #define HAS_BLUETOOTH false
             #define HAS_CONSOLE false
             #define HAS_PMU false

--- a/Config.h
+++ b/Config.h
@@ -23,7 +23,7 @@
 	#define MIN_VERS  0x46
 
 	#define PLATFORM_AVR   0x90
-  #define PLATFORM_ESP32 0x80
+  	#define PLATFORM_ESP32 0x80
     #define PLATFORM_NRF52 0x70
 
 	#define MCU_1284P 0x91
@@ -373,10 +373,10 @@
         const int pin_busy = -1;
     #endif
 
-    #if MODEM == SX1262
+    /*#if MODEM == SX1262
         SPIClass spiModem(NRF_SPIM2, pin_miso, pin_sclk, pin_mosi);
-    #endif
-
+    #endif*/
+	
 	// MCU independent configuration parameters
 	const long serial_baudrate  = 115200;
 

--- a/Config.h
+++ b/Config.h
@@ -40,6 +40,7 @@
 	#define BOARD_LORA32_V2_1   0x37
 	#define BOARD_LORA32_V1_0   0x39
 	#define BOARD_HELTEC32_V2   0x38
+	#define BOARD_HELTEC32_V3   0x42
 	#define BOARD_RNODE_NG_20   0x40
 	#define BOARD_RNODE_NG_21   0x41
 	#define BOARD_GENERIC_NRF52 0x50
@@ -253,6 +254,28 @@
 			#define HAS_BLUETOOTH true
             #define HAS_CONSOLE true
             #define HAS_EEPROM true
+		#elif BOARD_MODEL == BOARD_HELTEC32_V3
+            #define HAS_EEPROM false
+            #define HAS_DISPLAY false // set for debugging
+            #define HAS_BLUETOOTH false
+            #define HAS_CONSOLE false
+            #define HAS_PMU false
+            #define HAS_NP false
+            #define HAS_SD false
+            #define HAS_TCXO false
+            #define HAS_RXEN_BUSY true
+            #define MODEM SX1262
+            // following pins are for the sx1262
+            const int pin_rxen = -1;
+            const int pin_reset = 12;
+            const int pin_cs = 8;
+            const int pin_sclk = 9;
+            const int pin_mosi = 10;
+            const int pin_miso = 11;
+            const int pin_busy = 13;
+            const int pin_dio = 14;
+            const int pin_led_rx = 35;
+            const int pin_led_tx = pin_led_rx;
 		#elif BOARD_MODEL == BOARD_RNODE_NG_20
             #define HAS_DISPLAY true
             #define HAS_BLUETOOTH true

--- a/Device.h
+++ b/Device.h
@@ -151,7 +151,9 @@ bool device_init() {
     mbedtls_md_init(&ctx);
     mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(md_type), 0);
     mbedtls_md_starts(&ctx);
-    mbedtls_md_update(&ctx, dev_bt_mac, BT_DEV_ADDR_LEN);
+    #if HAS_BLUETOOTH == true
+      mbedtls_md_update(&ctx, dev_bt_mac, BT_DEV_ADDR_LEN);
+    #endif
     mbedtls_md_update(&ctx, dev_eeprom_signature, EEPROM_SIG_LEN);
     mbedtls_md_finish(&ctx, dev_hash);
     mbedtls_md_free(&ctx);

--- a/Display.h
+++ b/Display.h
@@ -107,6 +107,9 @@ bool display_init() {
     #elif BOARD_MODEL == BOARD_HELTEC32_V2
       Wire.begin(SDA_OLED, SCL_OLED);
     #elif BOARD_MODEL == BOARD_HELTEC32_V3
+      int pin_display_pwr = 37;
+      digitalWrite(pin_display_pwr, HIGH);
+      delay(500); //half a second should be enough
       Wire.begin(SDA_OLED, SCL_OLED);
     #elif BOARD_MODEL == BOARD_LORA32_V1_0
       int pin_display_en = 16;

--- a/Display.h
+++ b/Display.h
@@ -32,6 +32,11 @@
   #define DISP_ADDR 0x3C
   #define SCL_OLED 15
   #define SDA_OLED 4
+#elif BOARD_MODEL == BOARD_HELTEC32_V3
+  #define DISP_RST 21
+  #define DISP_ADDR 0x3C
+  #define SCL_OLED 18
+  #define SDA_OLED 17
 #elif BOARD_MODEL == BOARD_RNODE_NG_21
   #define DISP_RST -1
   #define DISP_ADDR 0x3C
@@ -101,6 +106,8 @@ bool display_init() {
       digitalWrite(pin_display_en, HIGH);
     #elif BOARD_MODEL == BOARD_HELTEC32_V2
       Wire.begin(SDA_OLED, SCL_OLED);
+    #elif BOARD_MODEL == BOARD_HELTEC32_V3
+      Wire.begin(SDA_OLED, SCL_OLED);
     #elif BOARD_MODEL == BOARD_LORA32_V1_0
       int pin_display_en = 16;
       digitalWrite(pin_display_en, LOW);
@@ -140,6 +147,9 @@ bool display_init() {
         disp_mode = DISP_MODE_LANDSCAPE;
         display.setRotation(0);
       #elif BOARD_MODEL == BOARD_HELTEC32_V2
+        disp_mode = DISP_MODE_PORTRAIT;
+        display.setRotation(1);
+      #elif BOARD_MODEL == BOARD_HELTEC32_V3
         disp_mode = DISP_MODE_PORTRAIT;
         display.setRotation(1);
       #else

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -89,8 +89,10 @@
     int fifo_tx_addr_ptr = 0;
     int fifo_rx_addr_ptr = 0;
     uint8_t packet[256] = {0};
-    extern SPIClass spiModem;
-    #define SPI spiModem
+    #if defined(NRF52840_XXAA)
+      extern SPIClass spiModem;
+      #define SPI spiModem
+    #endif
 
 
 #elif MODEM == SX1276 || MODEM == SX1278

--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -28,8 +28,8 @@
 #ifndef MCU_VARIANT
   #error No MCU variant defined, cannot compile
 #endif
-
-#if MCU_VARIANT == MCU_ESP32
+//heltec32 v3 is not compatible with rtc_wdt.h
+#if MCU_VARIANT == MCU_ESP32 and !defined(CONFIG_IDF_TARGET_ESP32S3)
   #include "soc/rtc_wdt.h"
   #define ISR_VECT IRAM_ATTR
 #else

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ firmware-heltec32_v2_extled:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V2 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x38\" \"-DEXTERNAL_LEDS=true\" \"-DMODEM=0x01\""
 
 firmware-heltec32_v3:
-	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x38\" \"-DMODEM=0x03\""
+	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DMODEM=0x03\""
 
 firmware-rnode_ng_20:
 	arduino-cli compile --fqbn esp32:esp32:ttgo-lora32 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x40\" \"-DMODEM=0x01\""

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ firmware-heltec32_v2:
 firmware-heltec32_v2_extled:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V2 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x38\" \"-DEXTERNAL_LEDS=true\" \"-DMODEM=0x01\""
 
+firmware-heltec32_v3:
+	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x38\" \"-DMODEM=0x03\""
+
 firmware-rnode_ng_20:
 	arduino-cli compile --fqbn esp32:esp32:ttgo-lora32 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x40\" \"-DMODEM=0x01\""
 
@@ -141,6 +144,9 @@ upload-heltec32_v2:
 	rnodeconf /dev/ttyUSB0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware.ino.bin)
 	@sleep 3
 	python ./Release/esptool/esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+
+upload-heltec32_v3:
+	arduino-cli upload -p /dev/ttyUSB0 --fqbn esp32:esp32:heltec_wifi_lora_32_V3
 
 upload-rnode_ng_20:
 	arduino-cli upload -p /dev/ttyUSB0 --fqbn esp32:esp32:ttgo-lora32

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,8 @@ upload-heltec32_v2:
 
 upload-heltec32_v3:
 	arduino-cli upload -p /dev/ttyUSB0 --fqbn esp32:esp32:heltec_wifi_lora_32_V3
+	@sleep 1
+	rnodeconf /dev/ttyUSB0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware.ino.bin)
 
 upload-rnode_ng_20:
 	arduino-cli upload -p /dev/ttyUSB0 --fqbn esp32:esp32:ttgo-lora32

--- a/Utilities.h
+++ b/Utilities.h
@@ -43,7 +43,7 @@
 #if MCU_VARIANT == MCU_ESP32 || MCU_VARIANT == MCU_NRF52
 	#include "Device.h"
 #endif
-#if MCU_VARIANT == MCU_ESP32
+#if MCU_VARIANT == MCU_ESP32 and !defined(CONFIG_IDF_TARGET_ESP32S3)
   #include "soc/rtc_wdt.h"
   #define ISR_VECT IRAM_ATTR
 #else

--- a/Utilities.h
+++ b/Utilities.h
@@ -1268,7 +1268,7 @@ bool eeprom_model_valid() {
 	#elif BOARD_MODEL == BOARD_HELTEC32_V2
 	if (model == MODEL_C4 || model == MODEL_C9) {
 	#elif BOARD_MODEL == BOARD_HELTEC32_V3
-	if true { //debug
+	if (true) { //debug
     #elif BOARD_MODEL == BOARD_RAK4630
     if (model == MODEL_FF) {
 	#elif BOARD_MODEL == BOARD_HUZZAH32

--- a/Utilities.h
+++ b/Utilities.h
@@ -169,6 +169,18 @@ uint8_t boot_vector = 0x00;
 			void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
 			void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
 		#endif
+	#elif BOARD_MODEL == BOARD_HELTEC32_V3
+		#if defined(EXTERNAL_LEDS)
+			void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
+			void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
+			void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
+			void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
+		#else
+			void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
+			void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
+			void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
+			void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
+		#endif
 	#elif BOARD_MODEL == BOARD_LORA32_V2_1
 		void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
 		void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
@@ -1255,6 +1267,8 @@ bool eeprom_model_valid() {
 	if (model == MODEL_B4 || model == MODEL_B9) {
 	#elif BOARD_MODEL == BOARD_HELTEC32_V2
 	if (model == MODEL_C4 || model == MODEL_C9) {
+	#elif BOARD_MODEL == BOARD_HELTEC32_V3
+	if true { //debug
     #elif BOARD_MODEL == BOARD_RAK4630
     if (model == MODEL_FF) {
 	#elif BOARD_MODEL == BOARD_HUZZAH32


### PR DESCRIPTION
The Heltec 32 V3 is the successor to the Heltec 32 V2 and any attempts to purchase the V2 result in getting the V3. It is one of the most common LoRa boards used by Meshtastic users due to its price. Getting it to work with RNode-Firmware would make building an RNode in the United States or migration from Meshtastic to Reticulum significantly easier.

This is a DRAFT pull request to create a build for the Heltec 32 V3. 
I have gotten rnode-firmware to successfully:

- compile (w/ESP32S3+SX1262)
- use the LCD on the Heltec 32 V3

This firmware does not boot yet. Any help getting it to boot would be appreciated. 