### PR TITLE
Fix RSSI miscalculation and TX power cap

### DIFF
--- a/LoRa.cpp
+++ b/LoRa.cpp
@@ -775,7 +775,7 @@ int ISR_VECT LoRaClass::packetRssi() {
     // may need more calculations here
     uint8_t buf[3] = {0};
     executeOpcodeRead(OP_PACKET_STATUS, buf, 3);
-    int pkt_rssi = -(int(buf[2])) / 2;
+    int pkt_rssi = -buf[0] / 2;
     return pkt_rssi;
   #endif
 }
@@ -796,7 +796,7 @@ float ISR_VECT LoRaClass::packetSnr() {
   #elif MODEM == SX1262
     uint8_t buf[3] = {0};
     executeOpcodeRead(OP_PACKET_STATUS, buf, 3);
-    return float(buf[1]) / 4.0;
+    return float(buf[1]) * 0.25;
   #endif
 }
 

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -620,7 +620,7 @@ void serialCallback(uint8_t sbyte) {
         kiss_indicate_txpower();
       } else {
         int txp = sbyte;
-        if (txp > 17) txp = 17;
+        if (txp > 22) txp = 22;
 
         lora_txp = txp;
         if (op_mode == MODE_HOST) setTXPower();

--- a/Utilities.h
+++ b/Utilities.h
@@ -658,7 +658,7 @@ void kiss_indicate_stat_rssi() {
     #if MODEM == SX1276 || MODEM == SX1278
         uint8_t packet_rssi_val = (uint8_t)(last_rssi+rssi_offset);
     #elif MODEM == SX1262
-        uint8_t packet_rssi_val = (uint8_t)(last_rssi);
+        int8_t packet_rssi_val = (int8_t)(last_rssi+rssi_offset);
     #endif
 	serial_write(FEND);
 	serial_write(CMD_STAT_RSSI);


### PR DESCRIPTION
Fixed the RSSI error reported by issue #60.

Increased the TX power cap from 17 to 22, since the SX1262 supports
broadcasting at up to 22 dBm. This won't affect the SX1276 / 78 since they have
a TX power cap in the firmware anyway, which has been left untouched.
