### PR TITLE
Update Boards.h Heltec Lora32 V2

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -239,7 +239,7 @@
       #define HAS_CONSOLE true
       #define HAS_EEPROM true
       const int pin_cs = 18;
-      const int pin_reset = 23;
+      const int pin_reset = 14;
       const int pin_dio = 26;
       #if defined(EXTERNAL_LEDS)
         const int pin_led_rx = 36;


### PR DESCRIPTION
Fixed issue with RST pin. Incorrect pin currently defined causing issues with board when attempting to use rnsd and getting an error about port in use due to proper reset not happening. Confirmed pins here: https://resource.heltec.cn/download/WiFi_LoRa_32/WIFI_LoRa_32_V2.pdf