### PR TITLE
Increase max transmit power for sx127x boards to 20dbm.

### DIFF
--- a/sx127x.cpp
+++ b/sx127x.cpp
@@ -345,7 +345,7 @@ void sx127x::setTxPower(int level, int outputPin) {
 
   } else {
     if (level < 2) { level = 2; }
-    else if (level > 17) { level = 17; }
+    else if (level > 20) { level = 20; }
 
     writeRegister(REG_PA_DAC_7X, 0x84);
     writeRegister(REG_PA_CONFIG_7X, PA_BOOST_7X | (level - 2));


### PR DESCRIPTION
Hello! I have recently purchased two LoRa32 V2.1_1.6 (no TCXO, sx1276 variant (868/915/923MHz)) transcievers for use with Reticulum using the RNode firmware. While configuring my devices, I noticed that the [specification sheet](https://www.alldatasheet.com/datasheet-pdf/download/800239/SEMTECH/SX1276.html) allows for a maximum of 20dbm transmit power. Additionally, this is within the permissible maximum transmit power according to US law ([FCC Part 15.247(b)(3))](https://www.govinfo.gov/content/pkg/CFR-2010-title47-vol1/pdf/CFR-2010-title47-vol1-sec15-247.pdf)). This commit simply changes the maximum transmit power to 20, instead of 17. Tell me if there's something I missed!