### PR TITLE
Add support for RAK1921 OLED display and User Button on RAK4631 boards

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -559,7 +559,7 @@
   #elif MCU_VARIANT == MCU_NRF52
     #if BOARD_MODEL == BOARD_RAK4631
       #define HAS_EEPROM false
-      #define HAS_DISPLAY false
+      #define HAS_DISPLAY true
       #define HAS_BLUETOOTH false
       #define HAS_BLE true
       #define HAS_CONSOLE false

--- a/Boards.h
+++ b/Boards.h
@@ -569,6 +569,7 @@
       #define HAS_TCXO true
       #define HAS_RF_SWITCH_RX_TX true
       #define HAS_BUSY true
+      #define HAS_INPUT true
       #define DIO2_AS_RF_SWITCH true
       #define CONFIG_UART_BUFFER_SIZE 6144
       #define CONFIG_QUEUE_SIZE 6144
@@ -577,6 +578,8 @@
       #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
       #define BLE_MANUFACTURER "RAK Wireless"
       #define BLE_MODEL "RAK4640"
+
+      const int pin_btn_usr1 = 9;
 
       // Following pins are for the sx1262
       const int pin_rxen = 37;

--- a/Display.h
+++ b/Display.h
@@ -45,6 +45,12 @@
   #define DISP_ADDR 0x3C
   #define SCL_OLED 18
   #define SDA_OLED 17
+#elif BOARD_MODEL == BOARD_RAK4631
+  // RAK1921/SSD1306
+  #define DISP_RST -1
+  #define DISP_ADDR 0x3C
+  #define SCL_OLED 14
+  #define SDA_OLED 13
 #elif BOARD_MODEL == BOARD_RNODE_NG_21
   #define DISP_RST -1
   #define DISP_ADDR 0x3C
@@ -254,6 +260,9 @@ bool display_init() {
         disp_mode = DISP_MODE_PORTRAIT;
         display.setRotation(1);
       #elif BOARD_MODEL == BOARD_HELTEC32_V3
+        disp_mode = DISP_MODE_PORTRAIT;
+        display.setRotation(1);
+      #elif BOARD_MODEL == BOARD_RAK4631
         disp_mode = DISP_MODE_PORTRAIT;
         display.setRotation(1);
       #elif BOARD_MODEL == BOARD_TDECK

--- a/Display.h
+++ b/Display.h
@@ -263,8 +263,8 @@ bool display_init() {
         disp_mode = DISP_MODE_PORTRAIT;
         display.setRotation(1);
       #elif BOARD_MODEL == BOARD_RAK4631
-        disp_mode = DISP_MODE_PORTRAIT;
-        display.setRotation(1);
+        disp_mode = DISP_MODE_LANDSCAPE;
+        display.setRotation(0);
       #elif BOARD_MODEL == BOARD_TDECK
         disp_mode = DISP_MODE_PORTRAIT;
         display.setRotation(3);

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -1389,7 +1389,7 @@ void sleep_now() {
 }
 
 void button_event(uint8_t event, unsigned long duration) {
-  #if MCU_VARIANT == MCU_ESP32
+  #if MCU_VARIANT == MCU_ESP32 || MCU_VARIANT == MCU_NRF52
     if (display_blanked) {
       display_unblank();
     } else {


### PR DESCRIPTION
Adds support for the [RAK1921](https://store.rakwireless.com/products/rak1921-oled-display-panel) OLED display on [RAK4631](https://store.rakwireless.com/products/wisblock-meshtastic-starter-kit) boards.

![20241005_161026](https://github.com/user-attachments/assets/531cc1b0-18bb-4763-a73e-d2daea5b1d91)
