### PR TITLE
nRF52 BLE improvements

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -189,6 +189,7 @@
     bool device_init_done = false;
     bool eeprom_ok = false;
     bool firmware_update_mode = false;
+    bool serial_in_frame = false;
 
 	// Boot flags
 	#define START_FROM_BOOTLOADER 0x01

--- a/Utilities.h
+++ b/Utilities.h
@@ -668,6 +668,19 @@ void serial_write(uint8_t byte) {
 			Serial.write(byte);
 		} else {
 			SerialBT.write(byte);
+
+            #if MCU_VARIANT == MCU_NRF52 && HAS_BLE
+            // This ensures that the TX buffer is flushed after a frame is queued in serial.
+            // serial_in_frame is used to ensure that the flush only happens at the end of the frame
+            if (serial_in_frame && byte == FEND) {
+                SerialBT.flushTXD();
+                serial_in_frame = false;
+            }
+            else if (!serial_in_frame && byte == FEND) {
+                serial_in_frame = true;
+            }
+            #endif
+
 		}
 	#else
 		Serial.write(byte);


### PR DESCRIPTION
Improvements in the BLE functionality for the nRF52, backported from RNode Firmware CE.

Changes:
* Force pin entry on nRF52 pairing
* Increase connection interval for greater throughput
* Use TX buffer for serial transmission to increase throughput
