### PR TITLE
Fix incorrect SX1280 preamble calculation

### DIFF
--- a/sx128x.cpp
+++ b/sx128x.cpp
@@ -328,12 +328,15 @@ void sx128x::setPacketParams(uint32_t preamble, uint8_t headermode, uint8_t leng
   uint8_t m = 1;
   uint32_t preamblelen;
 
-  for (e <= 15; e++;) {
-      for (m <= 15; m++;) {
-          preamblelen = m * (uint32_t(1) << e);
+  while (e <= 15) {
+      while (m <= 15) {
+          preamblelen = m * (pow(2,e));
           if (preamblelen >= preamble) break;
+          m++;
       }
       if (preamblelen >= preamble) break;
+      m = 0;
+      e++;
   }
 
   buf[0] = (e << 4) | m;


### PR DESCRIPTION
Backported from RNode Firmware CE.
