### PR TITLE
Add support for Heltec T114

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -89,6 +89,12 @@
   #define MODEL_C5            0xC5 // Heltec Lora32 v3, 433 MHz
   #define MODEL_CA            0xCA // Heltec Lora32 v3, 868 MHz
 
+  // https://resource.heltec.cn/download/Mesh_Node_T114/Datasheet.pdf
+  #define PRODUCT_HELTEC_T114 0xC2 // Heltec Mesh Node T114
+  #define BOARD_HELTEC_T114   0x3C
+  #define MODEL_C6            0xC6 // Heltec Mesh Node T114, 470-510 MHz (HT-n5262-LF)
+  #define MODEL_C7            0xC7 // Heltec Mesh Node T114, 863-928 MHz (HT-n5262-HF)
+
   #define PRODUCT_RAK4631     0x10
   #define BOARD_RAK4631       0x51
   #define MODEL_11            0x11 // RAK4631, 433 Mhz
@@ -609,10 +615,94 @@
       const int pin_led_tx = LED_GREEN;
       const int pin_tcxo_enable = -1;
 
+    #elif BOARD_MODEL == BOARD_HELTEC_T114
+      #define MODEM SX1262
+      #define HAS_EEPROM false
+      #define HAS_DISPLAY true
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_CONSOLE false
+      #define HAS_PMU false
+      #define HAS_NP false
+      #define HAS_SD false
+      #define HAS_TCXO true
+      #define HAS_RF_SWITCH_RX_TX true
+      #define HAS_BUSY true
+      #define HAS_INPUT true
+      #define DIO2_AS_RF_SWITCH true
+      #define CONFIG_UART_BUFFER_SIZE 6144
+      #define CONFIG_QUEUE_SIZE 6144
+      #define CONFIG_QUEUE_MAX_LENGTH 200
+      #define EEPROM_SIZE 296
+      #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
+      #define BLE_MANUFACTURER "Heltec"
+      #define BLE_MODEL "HT-n5262"
+
+      // ADC
+      #define PIN_T114_ADC_EN 6
+
+      // External sensors
+      #define PIN_T114_VEXT_EN 21
+
+      // LED
+      #define LED_T114_GREEN 3
+      #define PIN_T114_LED 14
+
+      // SPI
+      #define PIN_T114_MOSI 22
+      #define PIN_T114_MISO 23
+      #define PIN_T114_SCK  19
+      #define PIN_T114_SS   24
+
+      // SX1262
+      #define PIN_T114_RST  25
+      #define PIN_T114_DIO1 20
+      #define PIN_T114_BUSY 17
+
+      // TFT
+      #define DISPLAY_SCALE 2
+      #define PIN_T114_TFT_MOSI 9
+      #define PIN_T114_TFT_MISO 11 // not connected
+      #define PIN_T114_TFT_SCK 8
+      #define PIN_T114_TFT_SS 11
+      #define PIN_T114_TFT_DC 12
+      #define PIN_T114_TFT_RST 2
+      #define PIN_T114_TFT_EN 3
+      #define PIN_T114_TFT_BLGT 15
+
+      // pins for buttons on Heltec T114
+      const int pin_btn_usr1 = 42;
+
+      // pins for sx1262 on Heltec T114
+      const int pin_rxen = -1;
+      const int pin_reset = PIN_T114_RST;
+      const int pin_cs = PIN_T114_SS;
+      const int pin_sclk = PIN_T114_SCK;
+      const int pin_mosi = PIN_T114_MOSI;
+      const int pin_miso = PIN_T114_MISO;
+      const int pin_busy = PIN_T114_BUSY;
+      const int pin_dio = PIN_T114_DIO1;
+      const int pin_led_rx = 35;
+      const int pin_led_tx = 35;
+      const int pin_tcxo_enable = -1;
+
+      // pins for ST7789 display on Heltec T114
+      const int DISPLAY_DC = PIN_T114_TFT_DC;
+      const int DISPLAY_CS = PIN_T114_TFT_SS;
+      const int DISPLAY_MISO = PIN_T114_TFT_MISO;
+      const int DISPLAY_MOSI = PIN_T114_TFT_MOSI;
+      const int DISPLAY_CLK = PIN_T114_TFT_SCK;
+      const int DISPLAY_BL_PIN = PIN_T114_TFT_BLGT;
+      const int DISPLAY_RST = PIN_T114_TFT_RST;
+
     #else
       #error An unsupported nRF board was selected. Cannot compile RNode firmware.
     #endif
 
+  #endif
+
+  #ifndef DISPLAY_SCALE
+    #define DISPLAY_SCALE 1
   #endif
 
   #ifndef HAS_RF_SWITCH_RX_TX

--- a/Boards.h
+++ b/Boards.h
@@ -626,7 +626,6 @@
       #define HAS_NP false
       #define HAS_SD false
       #define HAS_TCXO true
-      #define HAS_RF_SWITCH_RX_TX true
       #define HAS_BUSY true
       #define HAS_INPUT true
       #define DIO2_AS_RF_SWITCH true
@@ -674,7 +673,6 @@
       const int pin_btn_usr1 = 42;
 
       // pins for sx1262 on Heltec T114
-      const int pin_rxen = -1;
       const int pin_reset = PIN_T114_RST;
       const int pin_cs = PIN_T114_SS;
       const int pin_sclk = PIN_T114_SCK;

--- a/Boards.h
+++ b/Boards.h
@@ -623,7 +623,7 @@
       #define HAS_BLE true
       #define HAS_CONSOLE false
       #define HAS_PMU false
-      #define HAS_NP false
+      #define HAS_NP true
       #define HAS_SD false
       #define HAS_TCXO true
       #define HAS_BUSY true
@@ -646,6 +646,8 @@
       // LED
       #define LED_T114_GREEN 3
       #define PIN_T114_LED 14
+      #define NP_M 1
+      const int pin_np = PIN_T114_LED;
 
       // SPI
       #define PIN_T114_MOSI 22
@@ -720,6 +722,10 @@
   // in board configuration
   #ifndef OCP_TUNED
     #define OCP_TUNED 0x38
+  #endif
+
+  #ifndef NP_M
+    #define NP_M 0.15
   #endif
 
 #endif

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ prep-samd:
 prep-nrf:
 	arduino-cli core update-index --config-file arduino-cli.yaml
 	arduino-cli core install rakwireless:nrf52 --config-file arduino-cli.yaml
+	arduino-cli core install Heltec_nRF52:Heltec_nRF52 --config-file arduino-cli.yaml
+	arduino-cli config set library.enable_unsafe_install true
+	arduino-cli lib install --git-url https://github.com/liamcottle/st7789#b8e7e076714b670764139289d3829b0beff67edb
+	arduino-cli lib install --git-url https://github.com/liamcottle/esp8266-oled-ssd1306#e16cee124fe26490cb14880c679321ad8ac89c95
 	pip install adafruit-nrfutil --upgrade
 
 console-site:
@@ -128,6 +132,9 @@ firmware-genericesp32: check_bt_buffers
 
 firmware-rak4631:
 	arduino-cli compile --log --fqbn rakwireless:nrf52:WisCoreRAK4631Board -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x51\""
+
+firmware-heltec-t114:
+	arduino-cli compile --log --fqbn heltec:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
 
 upload:
 	arduino-cli upload -p /dev/ttyUSB0 --fqbn unsignedio:avr:rnode
@@ -229,7 +236,8 @@ upload-featheresp32:
 upload-rak4631:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn rakwireless:nrf52:WisCoreRAK4631Board
 
-
+upload-heltec-t114:
+	arduino-cli upload -p /dev/cu.usbmodem14401 --fqbn heltec:Heltec_nRF52:HT-n5262
 
 release: release-all
 
@@ -432,3 +440,8 @@ release-rak4631:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x51\""
 	cp build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware.ino.hex build/rnode_firmware_rak4631.hex
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_rak4631.hex Release/rnode_firmware_rak4631.zip
+
+release-heltec-t114:
+	arduino-cli compile --fqbn heltec:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
+	cp build/heltec.Heltec_nRF52.HT-n5262/RNode_Firmware.ino.hex build/rnode_firmware_heltec_t114.hex
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_heltec_t114.hex Release/rnode_firmware_heltec_t114.zip

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -105,9 +105,9 @@ void setup() {
     led_init();
   #endif
 
-  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_RNODE_NG_22 && BOARD_MODEL != BOARD_TBEAM_S_V1
+  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114  && BOARD_MODEL != BOARD_RNODE_NG_22 && BOARD_MODEL != BOARD_TBEAM_S_V1
   // Some boards need to wait until the hardware UART is set up before booting
-  // the full firmware. In the case of the RAK4631, the line below will wait
+  // the full firmware. In the case of the RAK4631 and Heltec T114, the line below will wait
   // until a serial connection is actually established with a master. Thus, it
   // is disabled on this platform.
     while (!Serial);

--- a/Utilities.h
+++ b/Utilities.h
@@ -258,6 +258,12 @@ uint8_t boot_vector = 0x00;
 		void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
 		void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
 		void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
+	#elif BOARD_MODEL == BOARD_HELTEC_T114
+        // Heltec T114 pulls pins LOW to turn on
+        void led_rx_on()  { digitalWrite(pin_led_rx, LOW); }
+        void led_rx_off() {	digitalWrite(pin_led_rx, HIGH); }
+        void led_tx_on()  { digitalWrite(pin_led_tx, LOW); }
+        void led_tx_off() { digitalWrite(pin_led_tx, HIGH); }
     #endif
 #endif
 
@@ -1118,6 +1124,9 @@ void setTXPower() {
 		if (model == MODEL_11) LoRa->setTxPower(lora_txp, PA_OUTPUT_RFO_PIN);
 		if (model == MODEL_12) LoRa->setTxPower(lora_txp, PA_OUTPUT_RFO_PIN);
 
+		if (model == MODEL_C6) LoRa->setTxPower(lora_txp, PA_OUTPUT_RFO_PIN);
+        if (model == MODEL_C7) LoRa->setTxPower(lora_txp, PA_OUTPUT_RFO_PIN);
+
 		if (model == MODEL_A1) LoRa->setTxPower(lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 		if (model == MODEL_A2) LoRa->setTxPower(lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 		if (model == MODEL_A3) LoRa->setTxPower(lora_txp, PA_OUTPUT_RFO_PIN);
@@ -1370,7 +1379,7 @@ bool eeprom_product_valid() {
 	#elif PLATFORM == PLATFORM_ESP32
 	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1) {
 	#elif PLATFORM == PLATFORM_NRF52
-	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HMBRW) {
+	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_HMBRW) {
 	#else
 	if (false) {
 	#endif
@@ -1412,6 +1421,8 @@ bool eeprom_model_valid() {
 	if (model == MODEL_C4 || model == MODEL_C9) {
 	#elif BOARD_MODEL == BOARD_HELTEC32_V3
 	if (model == MODEL_C5 || model == MODEL_CA) {
+    #elif BOARD_MODEL == BOARD_HELTEC_T114
+    if (model == MODEL_C6 || model == MODEL_C7) {
     #elif BOARD_MODEL == BOARD_RAK4631
     if (model == MODEL_11 || model == MODEL_12) {
 	#elif BOARD_MODEL == BOARD_HUZZAH32

--- a/Utilities.h
+++ b/Utilities.h
@@ -106,7 +106,6 @@ uint8_t boot_vector = 0x00;
 #if HAS_NP == true
 	#include <Adafruit_NeoPixel.h>
 	#define NUMPIXELS 1
-	#define NP_M 0.15
 	Adafruit_NeoPixel pixels(NUMPIXELS, pin_np, NEO_GRB + NEO_KHZ800);
 
 	uint8_t npr = 0;
@@ -120,10 +119,17 @@ uint8_t boot_vector = 0x00;
   }
 
   void led_init() {
-  	if (EEPROM.read(eeprom_addr(ADDR_CONF_PSET)) == CONF_OK_BYTE) {
-  		uint8_t int_val = EEPROM.read(eeprom_addr(ADDR_CONF_PINT));
-  		led_set_intensity(int_val);
-  	}
+    #if MCU_VARIANT == MCU_NRF52
+      if (eeprom_read(eeprom_addr(ADDR_CONF_PSET)) == CONF_OK_BYTE) {
+        uint8_t int_val = eeprom_read(eeprom_addr(ADDR_CONF_PINT));
+        led_set_intensity(int_val);
+      }
+    #else
+    if (EEPROM.read(eeprom_addr(ADDR_CONF_PSET)) == CONF_OK_BYTE) {
+        uint8_t int_val = EEPROM.read(eeprom_addr(ADDR_CONF_PINT));
+        led_set_intensity(int_val);
+    }
+    #endif
   }
 
   void npset(uint8_t r, uint8_t g, uint8_t b) {
@@ -253,7 +259,12 @@ uint8_t boot_vector = 0x00;
 		void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
 	#endif
 #elif MCU_VARIANT == MCU_NRF52
-    #if BOARD_MODEL == BOARD_RAK4631
+    #if HAS_NP == true
+        void led_rx_on()  { npset(0, 0, 0xFF); }
+        void led_rx_off() {	npset(0, 0, 0); }
+        void led_tx_on()  { npset(0xFF, 0x50, 0x00); }
+        void led_tx_off() { npset(0, 0, 0); }
+    #elif BOARD_MODEL == BOARD_RAK4631
 		void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
 		void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
 		void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
@@ -469,6 +480,8 @@ unsigned long led_standby_ticks = 0;
 	#endif
 
 #elif MCU_VARIANT == MCU_NRF52
+        int led_standby_lng = 200;
+        int led_standby_cut = 100;
 		uint8_t led_standby_min = 200;
 		uint8_t led_standby_max = 255;
 		uint8_t led_notready_min = 0;

--- a/arduino-cli.yaml
+++ b/arduino-cli.yaml
@@ -2,4 +2,5 @@ board_manager:
   additional_urls:
   - https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
   - https://raw.githubusercontent.com/RAKwireless/RAKwireless-Arduino-BSP-Index/main/package_rakwireless_index.json
+  - https://github.com/HelTecAutomation/Heltec_nRF52/releases/download/1.7.0/package_heltec_nrf_index.json
   - http://unsigned.io/arduino/package_unsignedio_UnsignedBoards_index.json

--- a/sx126x.cpp
+++ b/sx126x.cpp
@@ -744,6 +744,8 @@ void sx126x::enableTCXO() {
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_RNODE_NG_22
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
+    #elif BOARD_MODEL == BOARD_HELTEC_T114
+      uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #endif
     executeOpcode(OP_DIO3_TCXO_CTRL_6X, buf, 4);
   #endif

--- a/sx128x.cpp
+++ b/sx128x.cpp
@@ -823,6 +823,7 @@ void sx128x::disableCrc()
 byte sx128x::random()
 {
     // todo: implement
+    return -1;
 }
 
 void sx128x::setPins(int ss, int reset, int dio0, int busy, int rxen, int txen)


### PR DESCRIPTION
This PR implements initial support for the Heltec T114.

- I have added a new `drawBitmap` method which allows for setting a `DISPLAY_SCALE` in `boards.h`.
- The Heltec T114 has a display scale set to `2`, all other boards default to a scale of `1`.
- Unfortunately the T114 display is just not quite wide enough to show all pixels, and cuts off the right side.
- I still decided to go with landscape mode, as most cases designed for this board are in landscape.
- The `drawLine` and `fillRect` methods had to be added as the `ST7789Spi` driver has a different method signature.
- I will investigate adding in support for the new display rotation eeprom setting for this board later on.

Related: https://github.com/markqvist/RNode_Firmware/issues/97