### PR TITLE
Fixed reading of battery voltage for Heltec V3.2. 

### DIFF
--- a/Power.h
+++ b/Power.h
@@ -95,10 +95,10 @@
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
 #elif BOARD_MODEL == BOARD_HELTEC32_V3
-  #define BAT_V_MIN       3.15
-  #define BAT_V_MAX       4.3
-  #define BAT_V_CHG       4.48
-  #define BAT_V_FLOAT     4.33
+  #define BAT_V_MIN       3.05
+  #define BAT_V_MAX       4.0
+  #define BAT_V_CHG       4.1
+  #define BAT_V_FLOAT     3.95
   #define BAT_SAMPLES     7
   const uint8_t pin_vbat = 1;
   const uint8_t pin_ctrl = 37;
@@ -348,8 +348,25 @@ bool init_pmu() {
     pinMode(pin_vbat, INPUT);
     return true;
   #elif BOARD_MODEL == BOARD_HELTEC32_V3
+    // there are three version of V3: V3, V3.1, and V3.2
+    // V3 and V3.1 have a pull up on pin_ctrl and are active low
+    // V3.2 has a transistor and active high
+    // put the pin input mode and read it.  if it's high, we have V3 or V3.1
+    // other wise, it's a V3.2
+    uint16_t pin_ctrl_value;
+    uint8_t pin_ctrl_active = LOW;
+    pinMode(pin_ctrl, INPUT);
+    pin_ctrl_value = digitalRead(pin_ctrl);
+    if(pin_ctrl_value == HIGH) {
+      // We have either a V3 or V3.1
+      pin_ctrl_active = LOW;
+    }
+    else {
+      // We have a V3.2
+      pin_ctrl_active = HIGH;
+    }
     pinMode(pin_ctrl,OUTPUT);
-    digitalWrite(pin_ctrl, LOW);
+    digitalWrite(pin_ctrl, pin_ctrl_active);
     return true;
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     pinMode(pin_ctrl,OUTPUT);


### PR DESCRIPTION
See my discussions with myself:  https://github.com/markqvist/Reticulum/discussions/805


…Comments from Power.h:

    // there are three version of V3: V3, V3.1, and V3.2
    // V3 and V3.1 have a pull up on pin_ctrl and are active low
    // V3.2 has a transistor and active high
    // put the pin input mode and read it.  if it's high, we have V3 or V3.1
    // other wise, it's a V3.2

Also, changed the min, max, float values for V3 boards.  From what I can see, most are sold with a battery like this:  https://www.amazon.com/dp/B0D3LMQSGL These batteries advertise a min voltage of 3 and max of 4.  Float should be a tiny bit below Max.