### PR TITLE
Fix generic esp32 reset pin

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -215,7 +215,7 @@
       #define HAS_CONSOLE true
       #define HAS_EEPROM true
       const int pin_cs = 4;
-      const int pin_reset = 36;
+      const int pin_reset = 33;
       const int pin_dio = 39;
       const int pin_led_rx = 14;
       const int pin_led_tx = 32;
@@ -256,7 +256,7 @@
       #define HAS_CONSOLE true
       #define HAS_EEPROM true
       const int pin_cs = 4;
-      const int pin_reset = 36;
+      const int pin_reset = 33;
       const int pin_dio = 39;
       const int pin_led_rx = 14;
       const int pin_led_tx = 32;


### PR DESCRIPTION
Fix for critical Issue: GPIO 36 on the ESP32 is an input-only pin (part of the ADC1 group along with GPIO 34, 35, and 39). This is a hardware limitation of the ESP32 microcontroller. These pins cannot be configured as outputs.

This means the current pin assignment in the firmware will not work correctly for the reset functionality, as pinMode(_reset, OUTPUT) and digitalWrite(_reset, LOW/HIGH) calls will fail to actually drive the pin. The reset pin for a generic ESP32 board should be reassigned to a GPIO that supports output mode (any GPIO that is not 34, 35, 36, or 39).

This appears to be a configuration error in the board definition that would prevent proper initialization of the SX1278 LoRa module on these board configurations.