### PR TITLE
Merge RAK4631 PMU logic from CE firmware + button change

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -710,6 +710,7 @@
   
   #elif MCU_VARIANT == MCU_NRF52
     #if BOARD_MODEL == BOARD_RAK4631
+      #define _PINNUM(port, pin) ((port) * 32 + (pin))
       #define HAS_EEPROM false
       #define HAS_DISPLAY true
       #define HAS_BLUETOOTH false
@@ -722,6 +723,7 @@
       #define HAS_RF_SWITCH_RX_TX true
       #define HAS_BUSY true
       #define HAS_INPUT true
+      #define HAS_SLEEP true
       #define DIO2_AS_RF_SWITCH true
       #define CONFIG_UART_BUFFER_SIZE 6144
       #define CONFIG_QUEUE_SIZE 6144
@@ -731,7 +733,9 @@
       #define BLE_MANUFACTURER "RAK Wireless"
       #define BLE_MODEL "RAK4640"
 
-      const int pin_btn_usr1 = 31;
+      #define PIN_VEXT_EN _PINNUM(1, 2)
+
+      const int pin_btn_usr1 = _PINNUM(0, 31);
 
       // Following pins are for the sx1262
       const int pin_rxen = 37;

--- a/Boards.h
+++ b/Boards.h
@@ -715,7 +715,7 @@
       #define HAS_BLUETOOTH false
       #define HAS_BLE true
       #define HAS_CONSOLE false
-      #define HAS_PMU false
+      #define HAS_PMU true
       #define HAS_NP false
       #define HAS_SD false
       #define HAS_TCXO true
@@ -731,7 +731,7 @@
       #define BLE_MANUFACTURER "RAK Wireless"
       #define BLE_MODEL "RAK4640"
 
-      const int pin_btn_usr1 = 9;
+      const int pin_btn_usr1 = 31;
 
       // Following pins are for the sx1262
       const int pin_rxen = 37;

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -88,6 +88,11 @@ void setup() {
       pinMode(PIN_LED_GREEN, OUTPUT);
       pinMode(PIN_LED_BLUE, OUTPUT);
       delay(200);
+    #elif BOARD_MODEL == BOARD_RAK4631
+      delay(200);
+      pinMode(PIN_VEXT_EN, OUTPUT);
+      digitalWrite(PIN_VEXT_EN, HIGH);
+      delay(200);
     #endif
 
     if (!eeprom_begin()) { Serial.write("EEPROM initialisation failed.\r\n"); }
@@ -1773,6 +1778,12 @@ void sleep_now() {
         delay(2000);
         analogWrite(PIN_VEXT_EN, 0);
         delay(100);
+      #elif BOARD_MODEL == BOARD_RAK4631
+        #if HAS_DISPLAY
+          display_intensity = 0;
+          update_display(true);
+        #endif
+        analogWrite(PIN_VEXT_EN, 0);
       #endif
       sd_power_gpregret_set(0, 0x6d);
       nrf_gpio_cfg_sense_input(pin_btn_usr1, NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);


### PR DESCRIPTION
The [liberatedsystems/RNode_Firmware_CE](https://github.com/liberatedsystems/RNode_Firmware_CE) has some PMU/Battery logic for the RAK4631. The voltage curves probably need some tweaking.

I also switched the user button to pin 31 as this is accessible from the board without having to add an IO module. See https://store.rokland.com/pages/adding-a-user-button-rak19007 for details.

Built and confirmed running on my own RAK4631