### PR TITLE
Add Wio Tracker L1 support

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -108,6 +108,11 @@
   #define BOARD_TECHO         0x44
   #define MODEL_16            0x16 // T-Echo 433 MHz
   #define MODEL_17            0x17 // T-Echo 868/915 MHz
+  
+  #define PRODUCT_WIO_L1      0x18 // Seeed Wio Tracker L1 devices
+  #define BOARD_WIO_L1        0x45
+  #define MODEL_18            0x18 // Wio Tracker L1, 433 MHz
+  #define MODEL_19            0x19 // Wio Tracker L1, 868/915 MHz
 
   #define PRODUCT_RAK4631     0x10
   #define BOARD_RAK4631       0x51
@@ -808,6 +813,45 @@
       const int pin_tcxo_enable = 21;
       const int pin_led_rx = PIN_LED_BLUE;
       const int pin_led_tx = PIN_LED_RED;
+
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      #define MODEM SX1262
+      #define HAS_EEPROM false
+      #define HAS_DISPLAY true
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_CONSOLE false
+      #define HAS_PMU false
+      #define HAS_NP false
+      #define HAS_SD false
+      #define HAS_TCXO true
+      #define HAS_RF_SWITCH_RX_TX true
+      #define HAS_BUSY true
+      #define HAS_INPUT true
+      #define DIO2_AS_RF_SWITCH true
+      #define CONFIG_UART_BUFFER_SIZE 6144
+      #define CONFIG_QUEUE_SIZE 6144
+      #define CONFIG_QUEUE_MAX_LENGTH 200
+      #define EEPROM_SIZE 296
+      #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
+      #define BLE_MANUFACTURER "Seeed Studio"
+      #define BLE_MODEL "Wio Tracker L1"
+
+      const int pin_btn_usr1 = 13; // Menu key (P0.08)
+
+      // SX1262 (Wio-SX1262 module)
+      const int pin_rxen = 5;  // Lora_sw (P1.08)
+      const int pin_txen = -1;
+      const int pin_reset = 2; // Lora_rst (P1.07)
+      const int pin_cs = 4;    // Lora_cs (P1.14)
+      const int pin_sclk = 8;  // Lora_sck (P0.30)
+      const int pin_mosi = 10; // Lora_mosi (P0.28)
+      const int pin_miso = 9;  // Lora_miso (P0.03)
+      const int pin_busy = 3;  // Lora_busy (P1.10)
+      const int pin_dio = 1;   // Lora_dio1 (P0.07)
+      const int pin_led_rx = 11; // Mesh LED (P1.01)
+      const int pin_led_tx = 11;
+      const int pin_tcxo_enable = -1;
 
     #elif BOARD_MODEL == BOARD_HELTEC_T114
       #define MODEM SX1262

--- a/Console/source/supported.md
+++ b/Console/source/supported.md
@@ -8,6 +8,7 @@ The RNode Firmware supports the following boards:
 - LilyGO LoRa32 v2.0 devices
 - LilyGO LoRa32 v2.1 devices
 - Heltec LoRa32 v2 devices
+- Seeed Wio Tracker L1 devices (915 MHz)
 - Homebrew RNodes based on ATmega1284p boards
 - Homebrew RNodes based on ATmega2560 boards
 - Homebrew RNodes based on Adafruit Feather ESP32 boards

--- a/Display.h
+++ b/Display.h
@@ -22,7 +22,7 @@
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     #include "ST7789.h"
     #define COLOR565(r, g, b) (((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xF8) >> 3))
-  #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+  #elif BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
     #include <Adafruit_SH110X.h>
   #else
     #include <Wire.h>
@@ -71,6 +71,12 @@
   #define DISP_ADDR 0x3C
   #define SCL_OLED 14
   #define SDA_OLED 13
+#elif BOARD_MODEL == BOARD_WIO_L1
+  #define DISP_RST -1
+  #define DISP_ADDR 0x3D
+  #define SCL_OLED 15
+  #define SDA_OLED 14
+  #define DISP_CUSTOM_ADDR true
 #elif BOARD_MODEL == BOARD_RNODE_NG_21
   #define DISP_RST -1
   #define DISP_ADDR 0x3C
@@ -112,7 +118,7 @@
   ST7789Spi display(&SPI1, DISPLAY_RST, DISPLAY_DC, DISPLAY_CS);
   #define SSD1306_WHITE ST77XX_WHITE
   #define SSD1306_BLACK ST77XX_BLACK
-#elif BOARD_MODEL == BOARD_TBEAM_S_V1
+#elif BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
   Adafruit_SH1106G display = Adafruit_SH1106G(128, 64, &Wire, -1);
   #define SSD1306_WHITE SH110X_WHITE
   #define SSD1306_BLACK SH110X_BLACK
@@ -225,7 +231,7 @@ void update_area_positions() {
 }
 
 uint8_t display_contrast = 0x00;
-#if BOARD_MODEL == BOARD_TBEAM_S_V1
+#if BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
   void set_contrast(Adafruit_SH1106G *display, uint8_t value) {
   }
 #elif BOARD_MODEL == BOARD_HELTEC_T114
@@ -323,6 +329,8 @@ bool display_init() {
       Wire.begin(SDA_OLED, SCL_OLED);
     #elif BOARD_MODEL == BOARD_XIAO_S3
       Wire.begin(SDA_OLED, SCL_OLED);
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      Wire.begin();
     #endif
 
     #if HAS_EEPROM
@@ -376,7 +384,7 @@ bool display_init() {
     // set white as default pixel colour for Heltec T114
     display.setRGB(COLOR565(0xFF, 0xFF, 0xFF));
     if (false) {
-    #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+    #elif BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
     if (!display.begin(display_address, true)) {
     #else
     if (!display.begin(SSD1306_SWITCHCAPVCC, display_address)) {
@@ -439,6 +447,15 @@ bool display_init() {
           display.setRotation(3);
         #endif
       }
+
+      #if BOARD_MODEL == BOARD_WIO_L1
+        // Force a clean OLED state on boot to clear any prior firmware remnants.
+        display.clearDisplay();
+        display.display();
+        delay(25);
+        display.clearDisplay();
+        display.display();
+      #endif
 
       update_area_positions();
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ prep-nrf:
 	arduino-cli core install rakwireless:nrf52 --config-file arduino-cli.yaml
 	arduino-cli core install Heltec_nRF52:Heltec_nRF52 --config-file arduino-cli.yaml
 	arduino-cli core install adafruit:nrf52 --config-file arduino-cli.yaml
+	arduino-cli lib install "Adafruit GFX Library"
+	arduino-cli lib install "Adafruit SSD1306"
+	arduino-cli lib install "Adafruit SH110X"
+	arduino-cli lib install "Crypto"
 	arduino-cli lib install "GxEPD2"
 	arduino-cli config set library.enable_unsafe_install true
 	arduino-cli lib install --git-url https://github.com/liamcottle/esp8266-oled-ssd1306#e16cee124fe26490cb14880c679321ad8ac89c95
@@ -148,6 +152,9 @@ firmware-heltec_t114:
 
 firmware-techo:
 	arduino-cli compile --log --fqbn adafruit:nrf52:pca10056 -e --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x44\""
+
+firmware-wio_l1:
+	arduino-cli compile --log --fqbn Seeeduino:nrf52:seeed_wio_tracker_L1 -e --build-cache-path /tmp/arduino-cache-$${USER} --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x45\""
 
 firmware-xiao_s3:
 	arduino-cli compile --log --fqbn "esp32:esp32:XIAO_ESP32S3" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""

--- a/Power.h
+++ b/Power.h
@@ -180,6 +180,23 @@ float pmu_temperature = PMU_TEMP_MIN-1;
   bool bat_voltage_dropping = false;
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
+#elif BOARD_MODEL == BOARD_WIO_L1
+  #define BAT_V_MIN       3.15
+  #define BAT_V_MAX       4.2
+  #define BAT_V_CHG       4.48
+  #define BAT_V_FLOAT     4.33
+  #define BAT_SAMPLES     7
+  const uint8_t pin_vbat = 16; // D16, P0.31
+  const uint8_t pin_ctrl = 30; // D30, P0.04 (BAT_adc_CTR)
+  float bat_p_samples[BAT_SAMPLES];
+  float bat_v_samples[BAT_SAMPLES];
+  uint8_t bat_samples_count = 0;
+  int bat_discharging_samples = 0;
+  int bat_charging_samples = 0;
+  int bat_charged_samples = 0;
+  bool bat_voltage_dropping = false;
+  float bat_delay_v = 0;
+  float bat_state_change_v = 0;
 #endif
 
 uint32_t last_pmu_update = 0;
@@ -202,7 +219,7 @@ void measure_temperature() {
 }
 
 void measure_battery() {
-  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO
+  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO || BOARD_MODEL == BOARD_WIO_L1
     battery_installed = true;
     #if BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4
       battery_indeterminate = false;
@@ -220,6 +237,8 @@ void measure_battery() {
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.017165;
     #elif BOARD_MODEL == BOARD_TECHO
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.007067;
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      float battery_measurement = (float)(analogRead(pin_vbat)) * 0.00704;
     #else
       float battery_measurement = (float)(analogRead(pin_vbat)) / 4095.0*7.26;
     #endif
@@ -412,6 +431,11 @@ bool init_pmu() {
   #endif
 
   #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_TECHO
+    pinMode(pin_vbat, INPUT);
+    return true;
+  #elif BOARD_MODEL == BOARD_WIO_L1
+    pinMode(pin_ctrl, OUTPUT);
+    digitalWrite(pin_ctrl, HIGH);
     pinMode(pin_vbat, INPUT);
     return true;
   #elif BOARD_MODEL == BOARD_HELTEC32_V3

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -129,7 +129,7 @@ void setup() {
     boot_seq();
   #endif
 
-  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_HELTEC32_V4
+  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_HELTEC32_V4 && BOARD_MODEL != BOARD_WIO_L1
     // Some boards need to wait until the hardware UART is set up before booting
     // the full firmware. In the case of the RAK4631 and Heltec T114, the line below will wait
     // until a serial connection is actually established with a master. Thus, it

--- a/Utilities.h
+++ b/Utilities.h
@@ -371,6 +371,13 @@ uint8_t boot_vector = 0x00;
 		void led_tx_off() { digitalWrite(pin_led_tx, LED_OFF); }
 		void led_id_on()  { }
 		void led_id_off() { }
+  #elif BOARD_MODEL == BOARD_WIO_L1
+		void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
+		void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
+		void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
+		void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
+		void led_id_on()  { }
+		void led_id_off() { }
 	#endif
 #endif
 
@@ -1381,6 +1388,9 @@ void setTXPower() {
 		if (model == MODEL_E3) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 		if (model == MODEL_E8) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 
+		if (model == MODEL_18) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
+		if (model == MODEL_19) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
+
 		if (model == MODEL_FE) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 		if (model == MODEL_FF) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_RFO_PIN);
 	}
@@ -1597,7 +1607,7 @@ bool eeprom_product_valid() {
 	#elif PLATFORM == PLATFORM_ESP32
 	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_H32_V4 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1  || rval == PRODUCT_XIAO_S3) {
 	#elif PLATFORM == PLATFORM_NRF52
-	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW) {
+	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_TECHO || rval == PRODUCT_WIO_L1 || rval == PRODUCT_HMBRW) {
 	#else
 	if (false) {
 	#endif
@@ -1649,6 +1659,8 @@ bool eeprom_model_valid() {
   if (model == MODEL_C6 || model == MODEL_C7) {
   #elif BOARD_MODEL == BOARD_RAK4631
   if (model == MODEL_11 || model == MODEL_12) {
+  #elif BOARD_MODEL == BOARD_WIO_L1
+  if (model == MODEL_18 || model == MODEL_19) {
 	#elif BOARD_MODEL == BOARD_HUZZAH32
 	if (model == MODEL_FF) {
 	#elif BOARD_MODEL == BOARD_GENERIC_ESP32

--- a/arduino-cli.yaml
+++ b/arduino-cli.yaml
@@ -4,4 +4,5 @@ board_manager:
   - https://raw.githubusercontent.com/RAKwireless/RAKwireless-Arduino-BSP-Index/main/package_rakwireless_index.json
   - https://github.com/HelTecAutomation/Heltec_nRF52/releases/download/1.7.0/package_heltec_nrf_index.json
   - https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
+  - https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
   - http://unsigned.io/arduino/package_unsignedio_UnsignedBoards_index.json

--- a/boards/seeed_wio_tracker_L1/variant.cpp
+++ b/boards/seeed_wio_tracker_L1/variant.cpp
@@ -1,0 +1,96 @@
+/*
+ * variant.cpp - Digital pin mapping for TRACKER L1
+ *
+ * This file defines the pin mapping array that maps logical digital pins (D0-D17)
+ * to physical GPIO ports/pins on the Nordic nRF52 series microcontroller.
+ *
+ * Board: [Seeed Studio WIO TRACKER L1]
+ * Hardware Features:
+ *  - LoRa module (CS/SCK/MISO/MOSI control pins)
+ *  - GNSS module (TX/RX/Reset/Wakeup)
+ *  - User LEDs (D11-D12)
+ *  - User button (D13)
+ *  - Grove/NFC interface (D14-D15)
+ *  - Battery voltage monitoring (D16)
+ *
+ * Created [20250521]
+ * By [Dylan]
+ */
+
+#include "variant.h"
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+/**
+ * @brief Digital pin to GPIO port/pin mapping table
+ *
+ * Format: Logical Pin (Dx) -> nRF Port.Pin (Px.xx)
+ *
+ */
+
+extern "C" {
+const uint32_t g_ADigitalPinMap[] = {
+    // D0 .. D10 - Peripheral control pins
+    41, // D0  P1.09    GNSS_WAKEUP
+    7,  // D1  P0.07     LORA_DIO1
+    39, // D2  P1,07     LORA_RESET
+    42, // D3  P1.10     LORA_BUSY
+    46, // D4  P1.14 (A4/SDA) LORA_CS
+    40, // D5  P1.08 (A5/SCL) LORA_SW
+    27, // D6  P0.27 (UART_TX) GNSS_TX
+    26, // D7  P0.26 (UART_RX) GNSS_RX
+    30, // D8  P0.30 (SPI_SCK) LORA_SCK
+    3,  // D9  P0.3 (SPI_MISO) LORA_MISO
+    28, // D10 P0.28 (SPI_MOSI) LORA_MOSI
+
+    // D11-D12 - LED outputs
+    33, // D11 P1.1 User LED
+    // Buzzzer
+    32, // D12 P1.0 Buzzer
+
+    // D13 - User input
+    8, // D13 P0.08 User Button
+
+    // D14-D15 - Grove interface
+    6, // D14 P0.06 OLED SDA
+    5, // D15 P0.05 OLED SCL
+
+    // D16 - Battery voltage ADC input
+    31, // D16 P0.31 VBAT_ADC
+    // GROVE
+    43, // D17 P0.00 GROVESDA
+    44, // D18 P0.01 GROVESCL
+
+    // FLASH
+    21, // D19 P0.21 (QSPI_SCK)
+    25, // D20 P0.25 (QSPI_CSN)
+    20, // D21 P0.20 (QSPI_SIO_0 DI)
+    24, // D22 P0.24 (QSPI_SIO_1 DO)
+    22, // D23 P0.22 (QSPI_SIO_2 WP)
+    23, // D24 P0.23 (QSPI_SIO_3 HOLD)
+
+    36, // D25 TB_UP
+    12, // D26 TB_DOWN
+    11, // D27 TB_LEFT
+    35, // D28 TB_RIGHT
+    37, // D29 TB_PRESS
+    4,  // D30 BAT_CTL
+};
+}
+
+void initVariant()
+{
+    pinMode(PIN_QSPI_CS, OUTPUT);
+    digitalWrite(PIN_QSPI_CS, HIGH);
+    // This setup is crucial for ensuring low power consumption and proper initialization of the hardware components.
+    // VBAT_ENABLE
+    pinMode(BAT_READ, OUTPUT);
+    digitalWrite(BAT_READ, HIGH);
+
+    pinMode(PIN_LED1, OUTPUT);
+    digitalWrite(PIN_LED1, LOW);
+    pinMode(PIN_LED2, OUTPUT);
+    digitalWrite(PIN_LED2, LOW);
+    pinMode(PIN_LED2, OUTPUT);
+}

--- a/boards/seeed_wio_tracker_L1/variant.h
+++ b/boards/seeed_wio_tracker_L1/variant.h
@@ -1,0 +1,181 @@
+#ifndef _SEEED_TRACKER_L1_H_
+#define _SEEED_TRACKER_L1_H_
+#include "WVariant.h"
+// ----------------------------------------
+//  Clock Configuration
+// ----------------------------------------
+#define VARIANT_MCK (64000000ul) // Master clock frequency
+#define USE_LFXO                 // 32.768kHz crystal for LFCLK
+
+// ----------------------------------------
+//  Pin Capacity Definitions
+// ----------------------------------------
+#define PINS_COUNT (33u)       // Total GPIO pins
+#define NUM_DIGITAL_PINS (33u) // Digital I/O pins
+#define NUM_ANALOG_INPUTS (8u) // Analog inputs (A0-A5 + VBAT + AREF)
+#define NUM_ANALOG_OUTPUTS (0u)
+
+// ----------------------------------------
+//  LED Configuration
+// ----------------------------------------
+//  LEDs
+//  LEDs
+#define PIN_LED1 (11) // LED        P1.15
+#define PIN_LED2 (12) //
+
+#define LED_GREEN PIN_LED1
+#define LED_BLUE PIN_LED2
+#define LED_STATE_ON 1 // State when LED is lit
+// ----------------------------------------
+//  Button Configuration
+// ----------------------------------------
+#define CANCEL_BUTTON_PIN D13 // This is the Program Button
+// #define BUTTON_NEED_PULLUP   1
+#define CANCEL_BUTTON_ACTIVE_LOW true
+#define CANCEL_BUTTON_ACTIVE_PULLUP false
+
+// #define BUTTON_PIN_TOUCH 13 // Touch button
+//  ----------------------------------------
+//   Digital Pin Mapping (D0-D10)
+//  ----------------------------------------
+#define D0 0   // P1.06 GNSS_WAKEUP/IO0
+#define D1 1   // P0.07 LORA_DIO1
+#define D2 2   // P1.07 LORA_RESET
+#define D3 3   // P1.10 LORA_BUSY
+#define D4 4   // P1.14 LORA_CS
+#define D5 5   // P1.08 LORA_SW
+#define D6 6   // P0.27 GNSS_TX
+#define D7 7   // P0.26 GNSS_RX
+#define D8 8   // P0.30 SPI_SCK
+#define D9 9   // P0.03 SPI_MISO
+#define D10 10 // P0.28 SPI_MOSI
+#define D12 12 // P1.00 Buzzer
+#define D13 13 // P0.08 User Button
+#define D14 14 // P0.05 OLED SCL
+#define D15 15 // P0.06 OLED SDA
+#define D16 16 // P0.31 VBAT_ADC
+#define D17 17 // P0.00 GROVE SDA
+#define D18 18 // P0.01 GROVE_SCL
+// ----------------------------------------
+//  Analog Pin Definitions
+// ----------------------------------------
+#define PIN_A0 0     // P0.02 Analog Input 0
+#define PIN_A1 1     // P0.03 Analog Input 1
+#define PIN_A2 2     // P0.28 Analog Input 2
+#define PIN_A3 3     // P0.29 Analog Input 3
+#define PIN_A4 4     // P0.04 Analog Input 4
+#define PIN_A5 5     // P0.05 Analog Input 5
+#define PIN_VBAT D16 // P0.31 Battery voltage sense
+// ----------------------------------------
+//  Communication Interfaces
+// ----------------------------------------
+//  I2C Configuration
+// #define HAS_WIRE 1
+#define PIN_WIRE_SDA D14 // P0.09
+#define PIN_WIRE_SCL D15 // P0.10
+#define WIRE_INTERFACES_COUNT 2
+#define PIN_WIRE1_SDA D18
+#define PIN_WIRE1_SCL D17
+#define I2C_NO_RESCAN
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+#define HAS_SCREEN 1
+#define USE_SSD1306 1
+
+// SPI Configuration (SX1262)
+
+#define SPI_INTERFACES_COUNT 1
+#define PIN_SPI_MISO 9  // P0.03 (D9)
+#define PIN_SPI_MOSI 10 // P0.28 (D10)
+#define PIN_SPI_SCK 8   // P0.30 (D8)
+
+// SX1262 LoRa Module Pins
+#define USE_SX1262
+#define SX126X_CS D4                 // Chip select
+#define SX126X_DIO1 D1               // Digital IO 1 (Interrupt)
+#define SX126X_BUSY D3               // Busy status
+#define SX126X_RESET D2              // Reset control
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8 // TCXO supply voltage
+#define SX126X_RXEN D5               // RX enable control
+#define SX126X_TXEN RADIOLIB_NC
+#define SX126X_DIO2_AS_RF_SWITCH // This Line is really necessary for SX1262  to work with RF switch or will loss TX power
+// ----------------------------------------
+//  Power Management
+// ----------------------------------------
+
+#define BAT_READ 30 // D30 = P0.04  Reads battery voltage from divider on signal board.
+#define BATTERY_SENSE_RESOLUTION_BITS 12
+#define ADC_MULTIPLIER 2.0
+#define BATTERY_PIN PIN_VBAT // PIN_A7
+#define AREF_VOLTAGE 3.6
+// ----------------------------------------
+//  GPS L76KB
+// ----------------------------------------
+#define GPS_L76K
+#ifdef GPS_L76K
+#define GPS_TX_PIN D6 // P0.26 - This is data from the MCU
+#define GPS_RX_PIN D7 // P0.27 - This is data from the GNSS
+#define HAS_GPS 1
+#define GPS_BAUDRATE 9600
+#define GPS_THREAD_INTERVAL 50
+#define PIN_SERIAL1_RX GPS_RX_PIN
+#define PIN_SERIAL1_TX GPS_TX_PIN
+
+#define PIN_GPS_STANDBY D0
+
+// #define GPS_DEBUG
+//  #define GPS_EN D18 // P1.05
+#endif
+
+// ----------------------------------------
+//  On-board QSPI Flash
+// ----------------------------------------
+// On-board QSPI Flash
+#define PIN_QSPI_SCK (21)
+#define PIN_QSPI_CS (22)
+#define PIN_QSPI_IO0 (23)
+#define PIN_QSPI_IO1 (24)
+#define PIN_QSPI_IO2 (25)
+#define PIN_QSPI_IO3 (26)
+
+#define EXTERNAL_FLASH_DEVICES P25Q16H
+#define EXTERNAL_FLASH_USE_QSPI
+
+// ----------------------------------------
+//  Buzzer
+// ----------------------------------------
+// Buzzer
+
+#define PIN_BUZZER D12 // P1.00, pwm output
+
+// ----------------------------------------
+//  joystick
+// ----------------------------------------
+
+#define CANNED_MESSAGE_ADD_CONFIRMATION 1
+
+// trackball
+#define HAS_TRACKBALL 1
+#define TB_UP 25
+#define TB_DOWN 26
+#define TB_LEFT 27
+#define TB_RIGHT 28
+#define TB_PRESS 29
+#define TB_DIRECTION FALLING
+// ----------------------------------------
+//  Compatibility Definitions
+// ----------------------------------------
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Serial port placeholders
+
+#define PIN_SERIAL2_RX (-1)
+#define PIN_SERIAL2_TX (-1)
+#ifdef __cplusplus
+}
+#endif
+
+#endif //  _SEEED_SOLAR_NODE_H_

--- a/sx126x.cpp
+++ b/sx126x.cpp
@@ -638,7 +638,7 @@ void sx126x::enableTCXO() {
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_HELTEC_T114
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
-    #elif BOARD_MODEL == BOARD_TECHO
+    #elif BOARD_MODEL == BOARD_TECHO || BOARD_MODEL == BOARD_WIO_L1
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_HELTEC32_V4
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};

--- a/tools/install_wio_l1_board.sh
+++ b/tools/install_wio_l1_board.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARDUINO_DATA_DIR="${ARDUINO_DATA_DIR:-$HOME/Library/Arduino15}"
+CORE_BASE="${ARDUINO_DATA_DIR}/packages/Seeeduino/hardware/nrf52"
+
+if [[ ! -d "${CORE_BASE}" ]]; then
+  echo "Seeeduino nrf52 core not found in ${CORE_BASE}"
+  echo "Install it with: arduino-cli core install Seeeduino:nrf52"
+  exit 1
+fi
+
+CORE_DIR="$(ls -d "${CORE_BASE}"/* | sort -V | tail -n1)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VARIANT_SRC="${SCRIPT_DIR}/../boards/seeed_wio_tracker_L1"
+VARIANT_DST="${CORE_DIR}/variants/seeed_wio_tracker_L1"
+BOARDS_TXT="${CORE_DIR}/boards.txt"
+
+mkdir -p "${VARIANT_DST}"
+cp "${VARIANT_SRC}/variant.h" "${VARIANT_DST}/variant.h"
+cp "${VARIANT_SRC}/variant.cpp" "${VARIANT_DST}/variant.cpp"
+
+tmp_boards="$(mktemp)"
+awk '
+  /^# WIO_L1_BEGIN/ {skip=1; next}
+  /^# WIO_L1_END/ {skip=0; next}
+  skip==1 {next}
+  /^seeed_wio_tracker_L1\./ {next}
+  {print}
+' "${BOARDS_TXT}" > "${tmp_boards}"
+mv "${tmp_boards}" "${BOARDS_TXT}"
+
+cp "${BOARDS_TXT}" "${BOARDS_TXT}.bak"
+cat >> "${BOARDS_TXT}" <<'EOF'
+
+# WIO_L1_BEGIN
+seeed_wio_tracker_L1.name=Seeed Wio Tracker L1
+
+seeed_wio_tracker_L1.vid.0=0x2886
+seeed_wio_tracker_L1.pid.0=0x1668
+seeed_wio_tracker_L1.vid.1=0x2886
+seeed_wio_tracker_L1.pid.1=0x1667
+
+seeed_wio_tracker_L1.bootloader.tool=bootburn
+seeed_wio_tracker_L1.upload.tool=nrfutil
+seeed_wio_tracker_L1.upload.protocol=nrfutil
+seeed_wio_tracker_L1.upload.use_1200bps_touch=true
+seeed_wio_tracker_L1.upload.wait_for_upload_port=true
+seeed_wio_tracker_L1.upload.maximum_size=815104
+seeed_wio_tracker_L1.upload.maximum_data_size=248832
+
+seeed_wio_tracker_L1.build.mcu=cortex-m4
+seeed_wio_tracker_L1.build.f_cpu=64000000
+seeed_wio_tracker_L1.build.board=Seeed_Wio_Tracker_L1
+seeed_wio_tracker_L1.build.core=nRF5
+seeed_wio_tracker_L1.build.variant=seeed_wio_tracker_L1
+seeed_wio_tracker_L1.build.usb_manufacturer="Seeed"
+seeed_wio_tracker_L1.build.usb_product="Wio Tracker L1"
+seeed_wio_tracker_L1.build.extra_flags=-DNRF52840_XXAA -DARDUINO_WIO_TRACKER_1110 -DARDUINO_MDBT50Q_RX {build.flags.usb}
+seeed_wio_tracker_L1.build.ldscript=nrf52840_s140_v7.ld
+seeed_wio_tracker_L1.build.vid=0x2886
+seeed_wio_tracker_L1.build.pid=0x1668
+
+seeed_wio_tracker_L1.menu.softdevice.s140v6=S140 7.3.0
+seeed_wio_tracker_L1.menu.softdevice.s140v6.build.sd_name=s140
+seeed_wio_tracker_L1.menu.softdevice.s140v6.build.sd_version=7.3.0
+seeed_wio_tracker_L1.menu.softdevice.s140v6.build.sd_fwid=0x0123
+
+seeed_wio_tracker_L1.menu.debug.l0=Level 0 (Release)
+seeed_wio_tracker_L1.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
+seeed_wio_tracker_L1.menu.debug.l1=Level 1 (Error Message)
+seeed_wio_tracker_L1.menu.debug.l1.build.debug_flags=-DCFG_DEBUG=1
+seeed_wio_tracker_L1.menu.debug.l2=Level 2 (Full Debug)
+seeed_wio_tracker_L1.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2
+seeed_wio_tracker_L1.menu.debug.l3=Level 3 (Segger SystemView)
+seeed_wio_tracker_L1.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
+seeed_wio_tracker_L1.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
+# WIO_L1_END
+EOF
+
+echo "Installed Wio Tracker L1 variant into ${CORE_DIR}"


### PR DESCRIPTION
Adds support for the Seeed Wio Tracker L1 (nRF52840, Wio‑SX1262).
Includes board pin map, OLED handling (SH1106 @ 0x3D), BLE + input wiring, and battery ADC.
Key changes

New IDs: PRODUCT_WIO_L1 (0x18), BOARD_WIO_L1 (0x45), MODEL_18/19.
Wio L1 pin map and hardware flags in [Boards.h](https://file+.vscode-resource.vscode-cdn.net/Users/james/.vscode/extensions/openai.chatgpt-0.4.68-darwin-arm64/webview/#).
OLED uses SH1106 driver; default address 0x3D ([Display.h](https://file+.vscode-resource.vscode-cdn.net/Users/james/.vscode/extensions/openai.chatgpt-0.4.68-darwin-arm64/webview/#)).
Battery ADC/CTRL support in [Power.h](https://file+.vscode-resource.vscode-cdn.net/Users/james/.vscode/extensions/openai.chatgpt-0.4.68-darwin-arm64/webview/#).
TCXO 1.8V for SX1262 in [sx126x.cpp](https://file+.vscode-resource.vscode-cdn.net/Users/james/.vscode/extensions/openai.chatgpt-0.4.68-darwin-arm64/webview/#).
Skip while(!Serial) for Wio L1 to avoid boot hang.
Makefile target firmware-wio_l1 + Seeed boards index in [arduino-cli.yaml](https://file+.vscode-resource.vscode-cdn.net/Users/james/.vscode/extensions/openai.chatgpt-0.4.68-darwin-arm64/webview/#).
Seeeduino variant files + install helper script.
Supported devices list updated.
Build / compile

Install deps (from repo root):

make -C RNode_Firmware prep-nrf
(This installs Adafruit GFX, SSD1306, SH110X, Crypto plus required cores.)

Build target:

make -C RNode_Firmware firmware-wio_l1
Or direct compile:

arduino-cli compile --fqbn Seeeduino:nrf52:seeed_wio_tracker_L1 -e \
  --build-path /tmp/wio_l1_build \
  --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x45\"" \
  RNode_Firmware
Notes

OLED controller on Wio L1 appears to be SH1106; SSD1306 left old screen artifacts. SH1106 driver resolves it.
OLED I2C address confirmed as 0x3D.
Testing

Built and flashed with arduino-cli (Seeeduino:nrf52:seeed_wio_tracker_L1).
Booted, OLED UI renders correctly.
BLE pairing and RNode interface operational.
EEPROM/signature validated; firmware hash set.