### PR TITLE
fix(heltec32_v4): set OCP_TUNED to 0x38 per SX1262 datasheet

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -403,7 +403,11 @@
       #define HAS_LORA_LNA true
       #define PIN_WAKEUP GPIO_NUM_0
       #define WAKEUP_LEVEL 0
-      #define OCP_TUNED 0x28
+      // SX1262 datasheet specifies OCP resets to 0x38 (140mA) after SetPaConfig
+      // for SX1262 devices (vs 0x18/60mA for SX1261). The Heltec V4 external PA
+      // draws from Vext, not the SX1262 supply rail, so the brownout risk that
+      // prompted lowering OCP on other boards does not apply here.
+      #define OCP_TUNED 0x38
       #define Vext GPIO_NUM_36
       #define LORA_PA_MODEL LORA_PA_UNKNOWN;
 


### PR DESCRIPTION
## Summary
                                                                                                                                                           
The SX1262 datasheet specifies that `SetPaConfig` resets OCP to **0x38 (140 mA)** for SX1262 devices, versus 0x18 (60 mA) for SX1261. The current `OCP_TUNED 0x28` (100 mA) was set conservatively after brownout issues on other boards (commit eab0284), but those boards share the SX1262 supply rail with the MCU. The Heltec V4's external PA draws from **Vext**, so that risk does not apply here.

Running 0x28 on the Heltec V4 produces observable symptoms:
- ~1 dB weaker signal at receiver (PA compressing at peak output)
- Long-window airtime accumulation drops from ~7% to ~2.8% despite identical packet counts

## Hardware validation

500-packet test at 22 dBm, 915 MHz, BW125, SF9, gap=0.8s:

| | OCP 0x38 (this PR) | OCP 0x28 (stock) |
|---|---|---|
| Packets sent / received | 500 / 500 | 500 / 500 |
| Errors / resets | 0 / 0 | 0 / 0 |
| Avg RSSI at receiver | -28.43 dBm | -29.45 dBm |
| TX noise floor max | -93 dBm | **-36 dBm** |
| Long-window airtime (TX) | 7.33% | 2.77% |
| Peak temperature | 72°C | 72°C |

Temperature is identical confirming the Vext PA topology isolates the SX1262 supply from PA current draw, making the brownout concern irrelevant for this board.

## Scope

Change is scoped to `BOARD_HELTEC32_V4` only. All other boards retain their existing OCP values.